### PR TITLE
docs: fixed the link to the coding conventions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,7 +83,7 @@ By encouraging coding conventions we ensure:
 * Facilitating copying, changing, and maintaining the code.
 * Sticking to C# best practices.
 
-Please follow our [Coding Conventions](#coding-conventions).
+Please follow our [Coding Conventions](CODING_CONVENTIONS.md).
 
 ## Source Control Commit Guidelines
 


### PR DESCRIPTION
### Description
coding conventions section in contributing was linking to itself while it should point to our coding conventions.

* Link to coding convention works now.

### Type of change

- [x] Docu fix 