### PR TITLE
fix: fixed possible NRE when properties start disabled

### DIFF
--- a/Runtime/Properties/GrabbableProperty.cs
+++ b/Runtime/Properties/GrabbableProperty.cs
@@ -30,17 +30,25 @@ namespace Innoactive.Creator.XRInteraction.Properties
         /// <summary>
         /// Reference to attached <see cref="InteractableObject"/>.
         /// </summary>
-        protected InteractableObject Interactable;
+        protected InteractableObject Interactable
+        {
+            get
+            {
+                if (interactable == false)
+                {
+                    interactable = GetComponent<InteractableObject>();
+                }
+
+                return interactable;
+            }
+        }
+
+        private InteractableObject interactable;
 
         protected override void OnEnable()
         {
             base.OnEnable();
-            
-            if (Interactable == false)
-            {
-                Interactable = gameObject.GetComponent<InteractableObject>();
-            }
-        
+
             Interactable.onSelectEnter.AddListener(HandleXRGrabbed);
             Interactable.onSelectExit.AddListener(HandleXRUngrabbed);
         }

--- a/Runtime/Properties/SnapZoneProperty.cs
+++ b/Runtime/Properties/SnapZoneProperty.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
-using Innoactive.Creator.Unity;
 using Innoactive.Creator.Core.Properties;
 using Innoactive.Creator.Core.Configuration.Modes;
 using Innoactive.Creator.BasicInteraction.Properties;
@@ -49,16 +48,24 @@ namespace Innoactive.Creator.XRInteraction.Properties
         /// <summary>
         /// Returns the SnapZone component.
         /// </summary>
-        public SnapZone SnapZone { get; protected set; }
+        public SnapZone SnapZone 
+        {
+            get
+            {
+                if (snapZone == null)
+                {
+                    snapZone = GetComponent<SnapZone>();
+                }
+
+                return snapZone;
+            }
+        }
+
+        private SnapZone snapZone;
         
         protected override void OnEnable()
         {
             base.OnEnable();
-            
-            if (SnapZone == false)
-            {
-                SnapZone = gameObject.GetOrAddComponent<SnapZone>();
-            }
 
             SnapZone.onSelectEnter.AddListener(HandleObjectSnapped);
             SnapZone.onSelectExit.AddListener(HandleObjectUnsnapped);
@@ -96,11 +103,6 @@ namespace Innoactive.Creator.XRInteraction.Properties
         
         private void InitializeModeParameters()
         {
-            if (SnapZone == null)
-            {
-                SnapZone = GetComponent<SnapZone>();
-            }
-
             if (IsShowingHoverMeshes == null)
             {
                 IsShowingHoverMeshes = new ModeParameter<bool>("ShowSnapzoneHoverMeshes", SnapZone.showInteractableHoverMeshes);

--- a/Runtime/Properties/TouchableProperty.cs
+++ b/Runtime/Properties/TouchableProperty.cs
@@ -29,16 +29,24 @@ namespace Innoactive.Creator.XRInteraction.Properties
         /// <summary>
         /// Reference to attached <see cref="InteractableObject"/>.
         /// </summary>
-        protected InteractableObject Interactable;
+        protected InteractableObject Interactable
+        {
+            get
+            {
+                if (interactable == false)
+                {
+                    interactable = GetComponent<InteractableObject>();
+                }
+
+                return interactable;
+            }
+        }
+
+        private InteractableObject interactable;
 
         protected override void OnEnable()
         {
             base.OnEnable();
-
-            if (Interactable == false)
-            {
-                Interactable = gameObject.GetComponent<InteractableObject>();
-            }
 
             Interactable.onFirstHoverEnter.AddListener(HandleXRTouched);
             Interactable.onLastHoverExit.AddListener(HandleXRUntouched);

--- a/Runtime/Properties/UsableProperty.cs
+++ b/Runtime/Properties/UsableProperty.cs
@@ -29,16 +29,24 @@ namespace Innoactive.Creator.XRInteraction.Properties
         /// <summary>
         /// Reference to attached <see cref="InteractableObject"/>.
         /// </summary>
-        protected InteractableObject Interactable;
+        protected InteractableObject Interactable
+        {
+            get
+            {
+                if (interactable == false)
+                {
+                    interactable = GetComponent<InteractableObject>();
+                }
+
+                return interactable;
+            }
+        }
+
+        private InteractableObject interactable;
 
         protected override void OnEnable()
         {
             base.OnEnable();
-
-            if (Interactable == false)
-            {
-                Interactable = gameObject.GetComponent<InteractableObject>();
-            }
 
             Interactable.onActivate.AddListener(HandleXRUsageStarted);
             Interactable.onDeactivate.AddListener(HandleXRUsageStopped);


### PR DESCRIPTION
### Description
we only got the reference to the interactable OnEnable which caused a npe when disabled objects where locked. Fixed it by adding a getter which cares about that.