### PR TITLE
The Snap Zone generator now handles invalid characters TRNG-1045

### DIFF
--- a/Editor/Properties/SnappablePropertyEditor.cs
+++ b/Editor/Properties/SnappablePropertyEditor.cs
@@ -150,7 +150,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
 
             if (prefab != null)
             {
-                Debug.LogWarningFormat("A new Snap Zone prefab was saved at {0}", prefabPath);
+                Debug.LogWarningFormat("A new highlight prefab was saved at {0}", prefabPath);
             }
             
             return prefab;

--- a/Editor/Properties/SnappablePropertyEditor.cs
+++ b/Editor/Properties/SnappablePropertyEditor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Text;
 using System.Collections.Generic;
 using Innoactive.Creator.XRInteraction;
 using Innoactive.Creator.XRInteraction.Properties;
@@ -63,7 +64,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
         
         private GameObject DuplicateObject(GameObject originalObject, Transform parent = null)
         {
-            GameObject cloneObject = new GameObject($"{originalObject.name}_Clone");
+            GameObject cloneObject = new GameObject($"{originalObject.name}Highlight.prefab");
             
             if (parent != null)
             {
@@ -144,8 +145,31 @@ namespace Innoactive.CreatorEditor.XRInteraction
             snapZoneBlueprint.transform.position = Vector3.zero;
             snapZoneBlueprint.transform.rotation = Quaternion.identity;
 
-            string prefabName = snapZoneBlueprint.name.Replace("_Clone", "Highlight.prefab");
-            return PrefabUtility.SaveAsPrefabAsset(snapZoneBlueprint, $"{PrefabPath}/{prefabName}");
+            string prefabName = NamePrefab(snapZoneBlueprint.name);
+            string prefabPath = $"{PrefabPath}/{prefabName}";
+            GameObject prefab = PrefabUtility.SaveAsPrefabAsset(snapZoneBlueprint, prefabPath);
+
+            if (prefab != null)
+            {
+                Debug.LogWarningFormat("A new Snap Zone prefab was saved at {0}", prefabPath);
+            }
+            
+            return prefab;
+        }
+
+        private string NamePrefab(string originalName)
+        {
+            int invalidCharacterIndex;
+            StringBuilder prefabName = new StringBuilder(originalName);
+
+            // Unity replaces invalid characters with '_' when creating new prefabs in the editor.
+            // We try to simulate that behavior.
+            while ((invalidCharacterIndex = prefabName.ToString().IndexOfAny(Path.GetInvalidFileNameChars())) >= 0)
+            {
+                prefabName.Replace(prefabName[invalidCharacterIndex], '_');
+            }
+            
+            return prefabName.ToString().Replace('\\', '_');
         }
     }
 }

--- a/Editor/Properties/SnappablePropertyEditor.cs
+++ b/Editor/Properties/SnappablePropertyEditor.cs
@@ -38,8 +38,8 @@ namespace Innoactive.CreatorEditor.XRInteraction
             
             SetHighlightMaterial(snapZoneBlueprint, settings.HighlightMaterial);
             GameObject snapZonePrefab = SaveSnapZonePrefab(snapZoneBlueprint);
-
-            GameObject snapObject = new GameObject($"{snappable.name}SnapZone");
+            
+            GameObject snapObject = new GameObject($"{CleanName(snappable.name)}_SnapZone");
             Undo.RegisterCreatedObjectUndo(snapObject, $"Create {snapObject.name}");
             EditorUtility.CopySerialized(snappable.transform, snapObject.transform);
             
@@ -64,7 +64,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
         
         private GameObject DuplicateObject(GameObject originalObject, Transform parent = null)
         {
-            GameObject cloneObject = new GameObject($"{originalObject.name}Highlight.prefab");
+            GameObject cloneObject = new GameObject($"{CleanName(originalObject.name)}_Highlight.prefab");
             
             if (parent != null)
             {
@@ -145,8 +145,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
             snapZoneBlueprint.transform.position = Vector3.zero;
             snapZoneBlueprint.transform.rotation = Quaternion.identity;
 
-            string prefabName = NamePrefab(snapZoneBlueprint.name);
-            string prefabPath = $"{PrefabPath}/{prefabName}";
+            string prefabPath = $"{PrefabPath}/{snapZoneBlueprint.name}";
             GameObject prefab = PrefabUtility.SaveAsPrefabAsset(snapZoneBlueprint, prefabPath);
 
             if (prefab != null)
@@ -157,19 +156,17 @@ namespace Innoactive.CreatorEditor.XRInteraction
             return prefab;
         }
 
-        private string NamePrefab(string originalName)
+        private string CleanName(string originalName)
         {
-            int invalidCharacterIndex;
-            StringBuilder prefabName = new StringBuilder(originalName);
-
             // Unity replaces invalid characters with '_' when creating new prefabs in the editor.
             // We try to simulate that behavior.
-            while ((invalidCharacterIndex = prefabName.ToString().IndexOfAny(Path.GetInvalidFileNameChars())) >= 0)
+            foreach (char invalidCharacter in Path.GetInvalidFileNameChars())
             {
-                prefabName.Replace(prefabName[invalidCharacterIndex], '_');
+                originalName = originalName.Replace(invalidCharacter, '_');
             }
-            
-            return prefabName.ToString().Replace('\\', '_');
+
+            // Non windows systems consider '\' as a valid file name. 
+            return originalName.Replace('\\', '_');
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: An issue when generating a snap zone from a snappable object with special characters like / or \ 

### Type of change
<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Create a snappable object named with invalid characters, generate a snap zone from it.