### PR TITLE
Scale of automated snap zones is always right. TRNG-1043

### DIFF
--- a/Editor/Properties/SnappablePropertyEditor.cs
+++ b/Editor/Properties/SnappablePropertyEditor.cs
@@ -32,20 +32,30 @@ namespace Innoactive.CreatorEditor.XRInteraction
         
         private void CreateSnapZone(SnappableProperty snappable)
         {
+            // Retrieves a SnapZoneSettings and creates a clone for the snappable object
             SnapZoneSettings settings = SnapZoneSettings.Settings;
             GameObject snapZoneBlueprint = DuplicateObject(snappable.gameObject);
             
+            // Sets the highlight materials to the cloned object and saves it as highlight prefab.
             SetHighlightMaterial(snapZoneBlueprint, settings.HighlightMaterial);
             GameObject snapZonePrefab = SaveSnapZonePrefab(snapZoneBlueprint);
 
+            // Creates a new object for the SnapZone.
             GameObject snapObject = new GameObject($"{snappable.name}SnapZone");
             Undo.RegisterCreatedObjectUndo(snapObject, $"Create {snapObject.name}");
-            EditorUtility.CopySerialized(snappable.transform, snapObject.transform);
             
+            // Positions the Snap Zone at the same position, rotation and scale as the snappable object.
+            snapObject.transform.SetParent(snappable.transform);
+            snapObject.transform.SetPositionAndRotation(snappable.transform.position, snappable.transform.rotation);
+            snapObject.transform.localScale = Vector3.one;
+            snapObject.transform.SetParent(null);
+            
+            // Adds a Snap Zone component to our new object.
             SnapZone snapZone = snapObject.AddComponent<SnapZoneProperty>().SnapZone;
             snapZone.ShownHighlightObject = snapZonePrefab;
             settings.ApplySettingsToSnapZone(snapZone);
 
+            // Calculates the volume of the Snap Zone out of the snappable object.
             Bounds bounds = new Bounds(Vector3.zero, Vector3.zero);
 
             foreach (Renderer renderer in snapZoneBlueprint.GetComponentsInChildren<Renderer>())
@@ -53,11 +63,13 @@ namespace Innoactive.CreatorEditor.XRInteraction
                 bounds.Encapsulate(renderer.bounds);
             }
             
+            // Adds a BoxCollider and sets it up.
             BoxCollider boxCollider = snapObject.AddComponent<BoxCollider>();
             boxCollider.center = bounds.center;
             boxCollider.size = bounds.size;
             boxCollider.isTrigger = true;
 
+            // Disposes the cloned object.
             DestroyImmediate(snapZoneBlueprint);
         }
         


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: An issue where the scale of Snap Zones generated from snappable objects child of another object, was off.

### Type of change
<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

1. Create an empty game object.
1. Create a cube inside the game object.
1. Set random position, rotation, and scale for both.
1. Add a snappable property to the cube.
1. Create a snap zone from the snap zone generator button in the snappble property (the cube).

The Snap Zone should imitate the position, rotation, and scale of the cube.