### PR TITLE
fix: add transform and offset it to the snap zone collider

### DIFF
--- a/Runtime/Properties/GrabbableProperty.cs
+++ b/Runtime/Properties/GrabbableProperty.cs
@@ -48,7 +48,7 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             InternalSetLocked(IsLocked);
         }
-        
+
         protected override void OnDisable()
         {
             base.OnDisable();


### PR DESCRIPTION
### Description
A fix that add an attach transform when you add a snap zone property to an object. It sets its offset to the collider's offset, if the snap zone has one.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

I added and reset snap zone properties for empty game object, for game objects with physical colliders only, for game objects with sphere, capsule, and cube with an offset.

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [X] My code follows the [Coding Conventions](#coding-conventions)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation - I am not sure if we should document it. It is quite self-explanatory for the user.
- [X] My changes generate no new warnings - it does in a specific case, but for a good reason and it is intended.
- [ ] I have added tests that prove my fix is effective or that my feature works - I could cover it with tests, yes.
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules - none.