### PR TITLE
fix: highlight property does not automatically add interactability

### DIFF
--- a/Runtime/Properties/GrabbableProperty.cs
+++ b/Runtime/Properties/GrabbableProperty.cs
@@ -45,6 +45,8 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             Interactable.onSelectEnter.AddListener(HandleXRGrabbed);
             Interactable.onSelectExit.AddListener(HandleXRUngrabbed);
+
+            InternalSetLocked(IsLocked);
         }
         
         protected override void OnDisable()
@@ -53,6 +55,12 @@ namespace Innoactive.Creator.XRInteraction.Properties
         
             Interactable.onSelectEnter.RemoveListener(HandleXRGrabbed);
             Interactable.onSelectExit.RemoveListener(HandleXRUngrabbed);
+        }
+        
+        protected void Reset()
+        {
+            Interactable.IsGrabbable = true;
+            gameObject.GetComponent<Rigidbody>().isKinematic = false;
         }
 
         private void HandleXRGrabbed(XRBaseInteractor interactor)

--- a/Runtime/Properties/HighlightProperty.cs
+++ b/Runtime/Properties/HighlightProperty.cs
@@ -1,12 +1,12 @@
 ﻿using UnityEngine;
 using Innoactive.Creator.Core.Properties;
+using Innoactive.Creator.Unity;
 
 namespace Innoactive.Creator.XRInteraction.Properties
 {
     /// <summary>
     /// Highlight property which enables an attached <see cref="InteractableObject"/>.
     /// </summary>
-    [RequireComponent(typeof(InteractableHighlighter))]
     public class HighlightProperty : BaseHighlightProperty
     {
         /// <summary>
@@ -28,6 +28,28 @@ namespace Innoactive.Creator.XRInteraction.Properties
             {
                 Highlighter = GetComponent<InteractableHighlighter>();
             }
+        }
+        
+        protected void Reset()
+        {
+            InteractableObject ownInteractableObject = gameObject.GetComponent<InteractableObject>();
+
+            // If gameObject was not interactable before, disable interactable functionality.
+            if (ownInteractableObject == null)
+            {
+                Rigidbody ownRigidbody = gameObject.GetComponent<Rigidbody>();
+                ownInteractableObject = gameObject.GetOrAddComponent<InteractableObject>();
+                ownInteractableObject.IsGrabbable = false;
+                ownInteractableObject.IsTouchable = false;
+                ownInteractableObject.IsUsable = false;
+                // If the gameObject had no rigidbody and thus was unaffected by physics, make it kinematic.
+                if (ownRigidbody == null)
+                {
+                    gameObject.GetOrAddComponent<Rigidbody>().isKinematic = true;
+                }
+            }
+
+            Highlighter = gameObject.GetOrAddComponent<InteractableHighlighter>();
         }
 
         /// <inheritdoc/>

--- a/Runtime/Properties/SnappableProperty.cs
+++ b/Runtime/Properties/SnappableProperty.cs
@@ -60,6 +60,8 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             Interactable.onSelectEnter.AddListener(HandleSnappedToDropZone);
             Interactable.onSelectExit.AddListener(HandleUnsnappedFromDropZone);
+
+            InternalSetLocked(IsLocked);
         }
         
         protected new virtual void OnDisable()

--- a/Runtime/Properties/TouchableProperty.cs
+++ b/Runtime/Properties/TouchableProperty.cs
@@ -44,6 +44,8 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             Interactable.onFirstHoverEnter.AddListener(HandleXRTouched);
             Interactable.onLastHoverExit.AddListener(HandleXRUntouched);
+
+            InternalSetLocked(IsLocked);
         }
 
         protected override void OnDisable()
@@ -52,6 +54,12 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             Interactable.onFirstHoverEnter.RemoveListener(HandleXRTouched);
             Interactable.onLastHoverExit.RemoveListener(HandleXRUntouched);
+        }
+        
+        protected void Reset()
+        {
+            Interactable.IsTouchable = true;
+            gameObject.GetComponent<Rigidbody>().isKinematic = false;
         }
 
         private void HandleXRTouched(XRBaseInteractor interactor)

--- a/Runtime/Properties/UsableProperty.cs
+++ b/Runtime/Properties/UsableProperty.cs
@@ -50,6 +50,8 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             Interactable.onActivate.AddListener(HandleXRUsageStarted);
             Interactable.onDeactivate.AddListener(HandleXRUsageStopped);
+
+            InternalSetLocked(IsLocked);
         }
 
         protected override void OnDisable()
@@ -58,6 +60,12 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             Interactable.onActivate.RemoveListener(HandleXRUsageStarted);
             Interactable.onDeactivate.RemoveListener(HandleXRUsageStopped);
+        }
+        
+        protected void Reset()
+        {
+            Interactable.IsUsable = true;
+            gameObject.GetComponent<Rigidbody>().isKinematic = false;
         }
 
         private void HandleXRUsageStarted(XRBaseInteractor interactor)


### PR DESCRIPTION
### Description
If the GameObject has not been an interactable object before, when adding the `HighlightProperty` it adds the `InteractableObject` component but disables the `IsTouchable`, `IsGrabbable`, and `IsUsable` flags. Besides, the added rigidbody is set to kinematic.
If the GameObject has been an interactable object before, the `InteractableObject` and rigidbody stay as they are.
Furthermore, the `TouchableProperty`, `GrabbableProperty`, and `UsableProperty` also make sure to set the flags properly after being added to the GameObject.

This bugfix uses the [MonoBehaviour.Reset](https://docs.unity3d.com/ScriptReference/MonoBehaviour.Reset.html) method by Unity.

**Fixes**: [TRNG-1033](https://jira.innoactive.de/browse/TRNG-1033)

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Adding each property (`HighlightProperty`. `TouchableProperty`, `GrabbableProperty`, and `UsableProperty`) in different order on multiple objects and make sure they set the `IsTouchable`, `IsGrabbable`, and `IsUsable` flags in the `InteractableObject` component properly.
Also tested with the `Fix it` button in the Step Inspector.

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (*Remark: Reset()-Method in MonoBehaviours only works in Editor, not during runtime*)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules