### PR TITLE
fix: fast forward snappables now snap immediately

### DIFF
--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -280,6 +280,7 @@ namespace Innoactive.Creator.XRInteraction
             if (interactable.IsSelectableBy(this))
             {
                 OnTriggerEnter(interactable.GetComponent<Collider>());
+                interactable.transform.position = attachTransform.position;
                 ForceSelectTarget = interactable;
             }
             else


### PR DESCRIPTION
### Description
Snappable objects when fast forwarded "hit"other objects on their way to the SnapZone cause those objects to fly away. Now the objects are first moved to the snap zones position before they eventually snap.

**Fixes**: TRNG-1069

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Set up 8 objects in a row and 8 SnapZones behind them. Snapping the first object into the first SnapZone so it has to "pass through" all other objects.

![image](https://user-images.githubusercontent.com/3699271/91310002-a152b080-e7b1-11ea-85cd-8f8df2985a95.png)
