### PR TITLE
fix: highlight now draws all submeshes not only the first

### DIFF
--- a/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
@@ -344,7 +344,10 @@ namespace Innoactive.Creator.XRInteraction
             Transform rendersTransform = renderer.transform;
             Matrix4x4 matrix = Matrix4x4.TRS(rendersTransform.position, rendersTransform.rotation, rendersTransform.lossyScale);
 
-            Graphics.DrawMesh(mesh, matrix, material, layerMask);
+            for (int i = 0; i < mesh.subMeshCount; i++)
+            {
+                Graphics.DrawMesh(mesh, matrix, material, layerMask, null, i);
+            }
         }
 
         private bool ShouldHighlightTouching()


### PR DESCRIPTION
### Description
The InteractableHighlighter only drew the first submesh of the mesh filter.
Now it draws all submeshes.

**Fixes**: # [TRNG-1061](https://jira.innoactive.de/browse/TRNG-1061)

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Using different objects with multiple meshes (submeshes) like the winkelschrauber.fbx provided in this ticket. Then highlight it with the highlight behavior.

![ezgif-4-3611073d0b20](https://user-images.githubusercontent.com/6626589/91443578-ce679780-e873-11ea-9df8-a9d46d379aac.gif)

**Test Configuration**:


### Aditional Notes
<!--- Please provide any additonal information -->

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x ] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules