### PR TITLE
Feature/visualizing snapzone content in editor trng 1047

### DIFF
--- a/Editor/Interaction/SnapZoneEditor.cs
+++ b/Editor/Interaction/SnapZoneEditor.cs
@@ -10,6 +10,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
     [CustomEditor(typeof(SnapZone))]
     internal class SnapZoneEditor : Editor
     {
+        private SerializedProperty showHighlightInEditor;
         private SerializedProperty shownHighlightObject;
         private SerializedProperty shownHighlightObjectColor;
         
@@ -33,6 +34,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
             public static readonly GUIContent AttachTransform = new GUIContent("Attach Transform", "Attach Transform to use for this Interactor.  Will create empty GameObject if none set.");
             public static readonly GUIContent StartingSelectedInteractable = new GUIContent("Starting Selected Interactable", "Interactable that will be selected upon start.");
             
+            public static readonly GUIContent ShowHighlightInEditor = new GUIContent("Show Highlight in Editor", "Enable this to show how the object will be positioned later on.");
             public static readonly GUIContent ShownHighlightObject = new GUIContent("Shown Highlight Object", "The game object whose mesh is drawn to emphasize the position of the snap zone. If none is supplied, no highlight object is shown.");
             public static readonly GUIContent ShownHighlightObjectColor = new GUIContent("Shown Highlight Object Color", "The color of the material used to draw the \"Shown Highlight Object\". Use the alpha value to specify the degree of transparency.");
             public static readonly GUIContent InteractableHoverMeshMaterial = new GUIContent("Validation Hover Material", "Material used for rendering interactable meshes on hover (a default material will be created if none is supplied).");
@@ -40,6 +42,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
 
         private void OnEnable()
         {
+            showHighlightInEditor = serializedObject.FindProperty("ShowHighlightInEditor");
             shownHighlightObject = serializedObject.FindProperty("shownHighlightObject");
             shownHighlightObjectColor = serializedObject.FindProperty("shownHighlightObjectColor");
             
@@ -72,6 +75,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
             EditorGUILayout.Space();
             EditorGUILayout.LabelField("Snap Zone", EditorStyles.boldLabel); 
             
+            EditorGUILayout.PropertyField(showHighlightInEditor, Tooltips.ShowHighlightInEditor);
             EditorGUILayout.PropertyField(shownHighlightObject, Tooltips.ShownHighlightObject);
             EditorGUILayout.PropertyField(shownHighlightObjectColor, Tooltips.ShownHighlightObjectColor);
             EditorGUILayout.PropertyField(interactableHoverMeshMaterial, Tooltips.InteractableHoverMeshMaterial);

--- a/Editor/Properties/SnappablePropertyEditor.cs
+++ b/Editor/Properties/SnappablePropertyEditor.cs
@@ -65,9 +65,8 @@ namespace Innoactive.CreatorEditor.XRInteraction
             snapPoint.transform.localPosition = Vector3.zero;
             snapPoint.transform.localScale = Vector3.one;
             snapPoint.transform.localRotation = Quaternion.identity;
-            SnapZonePreviewDrawer drawer = snapPoint.AddComponent<SnapZonePreviewDrawer>();
-            drawer.Parent = snapZone;
-            
+            snapPoint.AddComponent<SnapZonePreviewDrawer>();
+
             SerializedObject snapZoneSerialization = new SerializedObject(snapZone);
             SerializedProperty property = snapZoneSerialization.FindProperty("m_AttachTransform");
             property.objectReferenceValue = snapPoint.transform;

--- a/Editor/SnapZone/SnapZoneSettings.cs
+++ b/Editor/SnapZone/SnapZoneSettings.cs
@@ -31,14 +31,24 @@ namespace Innoactive.CreatorEditor.XRInteraction
         private Material highlightMaterial;
 
         /// <summary>
-        /// This color is used when an <see cref="InteractableObject"/> is hovering a <see cref="SnapZone"/>.
+        /// This color is used when a valid <see cref="InteractableObject"/> is hovering a <see cref="SnapZone"/>.
         /// </summary>
         [Tooltip("This color is used when a valid object is hovering the snap zone.")]
         public Color ValidationColor = new Color32(0, 255, 0, 50);
+        
+        /// <summary>
+        /// This color is used when an invalid <see cref="InteractableObject"/> is hovering a <see cref="SnapZone"/>.
+        /// </summary>
+        [Tooltip("This color is used when an invalid object is hovering the snap zone.")]
+        public Color InvalidColor = new Color32(255, 0, 0, 50);
 
         [SerializeField]
         [Tooltip("The material shown when a valid object is hovering the snap zone. Should be transparent.\n\n[This field overrides 'ValidHighlightColor']")]
         private Material validationMaterial;
+
+        [SerializeField]
+        [Tooltip("The material shown when an invalid object is hovering the snap zone. Should be transparent.\n\n[This field overrides 'InvalidHighlightColor']")]
+        private Material invalidMaterial;
 
         /// <summary>
         /// The material used for drawing when an <see cref="InteractableObject"/> is hovering a <see cref="SnapZone"/>. Should be transparent.
@@ -46,9 +56,14 @@ namespace Innoactive.CreatorEditor.XRInteraction
         public Material HighlightMaterial => SetupHighlightMaterial();
 
         /// <summary>
-        /// The material used for the highlight object. Should be transparent.
+        /// The material used for the highlight object, when a valid object is hovering. Should be transparent.
         /// </summary>
         public Material ValidationMaterial => SetupValidationMaterial();
+        
+        /// <summary>
+        /// The material used for the highlight object, when an invalid object is hovering. Should be transparent.
+        /// </summary>
+        public Material InvalidMaterial => SetupInvalidMaterial();
 
         /// <summary>
         /// Loads the first existing <see cref="SnapZoneSettings"/> found in the project.
@@ -64,6 +79,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
             snapZone.InteractionLayerMask = InteractionLayerMask;
             snapZone.ShownHighlightObjectColor = HighlightColor;
             snapZone.ValidationMaterial = ValidationMaterial;
+            snapZone.InvalidMaterial = InvalidMaterial;
         }
         
         private static SnapZoneSettings RetrieveSnapZoneSettings()
@@ -119,6 +135,26 @@ namespace Innoactive.CreatorEditor.XRInteraction
                 
             highlightMaterial.color = HighlightColor;
             return highlightMaterial;
+        }
+        
+        private Material SetupInvalidMaterial()
+        {
+            if (invalidMaterial == null)
+            {
+                invalidMaterial = CreateMaterial();
+                invalidMaterial.name = "SnapZoneInvalidMaterial";
+
+                if (Directory.Exists(MaterialsPath) == false)
+                {
+                    Directory.CreateDirectory(MaterialsPath);
+                }
+
+                AssetDatabase.CreateAsset(invalidMaterial, $"{MaterialsPath}/{invalidMaterial.name}.mat");
+                AssetDatabase.Refresh();
+            }
+                
+            invalidMaterial.color = InvalidColor;
+            return invalidMaterial;
         }
         
         private Material SetupValidationMaterial()

--- a/Resources/[XR_Setup].prefab
+++ b/Resources/[XR_Setup].prefab
@@ -1690,6 +1690,7 @@ MonoBehaviour:
   m_PlayHapticsOnHoverExit: 1
   m_HapticHoverExitIntensity: 0.25
   m_HapticHoverExitDuration: 0.125
+  precisionGrab: 1
 --- !u!1 &7978014071796457453
 GameObject:
   m_ObjectHideFlags: 0
@@ -2154,6 +2155,7 @@ MonoBehaviour:
   m_PlayHapticsOnHoverExit: 1
   m_HapticHoverExitIntensity: 0.25
   m_HapticHoverExitDuration: 0.125
+  precisionGrab: 1
 --- !u!1 &8767993477320427908
 GameObject:
   m_ObjectHideFlags: 0

--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -147,7 +147,6 @@ namespace Innoactive.Creator.XRInteraction
         protected override void OnSelectEnter(XRBaseInteractor interactor)
         {
             base.OnSelectEnter(interactor);
-            
             if (IsInSocket == false)
             {
                 XRSocketInteractor socket = interactor.GetComponent<XRSocketInteractor>();

--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -23,7 +23,7 @@ namespace Innoactive.Creator.XRInteraction
         [SerializeField]
         private bool isUsable = true;
 
-        private Rigidbody rigidbody;
+        private Rigidbody internalRigidbody;
         private XRSocketInteractor selectingSocket;
 
         /// <summary>
@@ -33,12 +33,12 @@ namespace Innoactive.Creator.XRInteraction
         {
             get
             {
-                if (rigidbody == null)
+                if (internalRigidbody == null)
                 {
-                    rigidbody = GetComponent<Rigidbody>();
+                    internalRigidbody = GetComponent<Rigidbody>();
                 }
                 
-                return rigidbody;
+                return internalRigidbody;
             }
         }
 

--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
+using Innoactive.Creator.BasicInteraction.Validation;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 
@@ -16,6 +17,11 @@ namespace Innoactive.Creator.XRInteraction
     /// </remarks>
     public class SnapZone : XRSocketInteractor
     {
+        /// <summary>
+        /// Gets or sets whether <see cref="ShownHighlightObject"/> is shown or not.
+        /// </summary>
+        public bool ShowHighlightObject { get; set; }
+        
         [SerializeField]
         private GameObject shownHighlightObject = null;
 
@@ -35,7 +41,7 @@ namespace Innoactive.Creator.XRInteraction
         
         [SerializeField]
         private Color shownHighlightObjectColor = new Color(0.8f, 0.0f, 1.0f, 0.6f);
-        
+
         /// <summary>
         /// The color of the material used to draw the <see cref="ShownHighlightObject"/>.
         /// Use the alpha value to specify the degree of transparency.
@@ -49,14 +55,13 @@ namespace Innoactive.Creator.XRInteraction
                 UpdateHighlightMeshFilterCache();
             }
         }
-
-        /// <summary>
-        /// Gets or sets whether <see cref="ShownHighlightObject"/> is shown or not.
-        /// </summary>
-        public bool ShowHighlightObject { get; set; }
         
-        private Material highlightMeshMaterial;
+        /// <summary>
+        /// Shows the highlight 
+        /// </summary>
+        public bool ShowHighlightInEditor = true;
 
+        private Material highlightMeshMaterial;
         /// <summary>
         /// The material used for drawing the mesh of the <see cref="ShownHighlightObject"/>. 
         /// </summary>
@@ -75,6 +80,7 @@ namespace Innoactive.Creator.XRInteraction
         }
 
         [SerializeField]
+        [Tooltip("Will be used when a valid object hovers the SnapZone")]
         private Material validationMaterial;
 
         /// <summary>
@@ -91,7 +97,28 @@ namespace Innoactive.Creator.XRInteraction
 
                 return validationMaterial;
             }
-            set { validationMaterial = value; }
+            set => validationMaterial = value;
+        }
+        
+        [SerializeField]
+        [Tooltip("Will be used when an invalid object hovers the SnapZone")]
+        private Material invalidMaterial;
+
+        /// <summary>
+        /// The material used for drawing when an invalid <see cref="InteractableObject"/> is hovering this <see cref="SnapZone"/>.
+        /// </summary>
+        public Material InvalidMaterial
+        {
+            get
+            {
+                if (invalidMaterial == null)
+                {
+                    invalidMaterial = CreateTransparentMaterial();
+                }
+
+                return invalidMaterial;
+            }
+            set => invalidMaterial = value;
         }
 
         /// <summary>
@@ -103,14 +130,34 @@ namespace Innoactive.Creator.XRInteraction
         /// Forces the socket interactor to select the given target, if it is not null.
         /// </summary>
         protected XRBaseInteractable ForceSelectTarget { get; set; }
-
-        private Material previewMaterial;
+        
         private Mesh previewMesh;
+        
+        internal Mesh PreviewMesh 
+        {
+            get
+            {
+                if (previewMesh == null && shownHighlightObject != null)
+                {
+                    UpdateHighlightMeshFilterCache();
+                }
+
+                return previewMesh;
+            }
+        }
+        
+        private Material activeMaterial;
+
+        private List<Validator> validators = new List<Validator>();
+
+        private Vector3 tmpCenterOfMass;
 
         protected override void Awake()
         {
             base.Awake();
 
+            validators = GetComponents<Validator>().ToList();
+            
             Collider triggerCollider = gameObject.GetComponentsInChildren<Collider>().FirstOrDefault(foundCollider => foundCollider.isTrigger);
             if (triggerCollider == null)
             {
@@ -120,33 +167,46 @@ namespace Innoactive.Creator.XRInteraction
 
             ShowHighlightObject = ShownHighlightObject != null;
 
+            activeMaterial = HighlightMeshMaterial;
+            
             if (ShownHighlightObject != null)
             {
                 UpdateHighlightMeshFilterCache();
             }
         }
+
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            
+            onSelectEnter.AddListener(OnAttach);
+            onSelectExit.AddListener(OnDetach);
+        }
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            
+            onSelectEnter.RemoveListener(OnAttach);
+            onSelectExit.RemoveListener(OnDetach);
+        }
+
+        private void OnAttach(XRBaseInteractable snappable)
+        {
+            Rigidbody rigid = snappable.gameObject.GetComponent<Rigidbody>();
+            tmpCenterOfMass = rigid.centerOfMass;
+            rigid.centerOfMass = Vector3.zero;
+        }
         
+        private void OnDetach(XRBaseInteractable snappable)
+        {
+            Rigidbody rigid = snappable.gameObject.GetComponent<Rigidbody>();
+            rigid.centerOfMass = tmpCenterOfMass;
+        }
+
         private void OnDrawGizmos()
         {
-            Collider collider = GetComponent<Collider>();
-
-            if (collider == null)
-            {
-                return;
-            }
-
-            Gizmos.color = shownHighlightObjectColor;
-            Gizmos.matrix = transform.localToWorldMatrix;
-
-            switch (collider)
-            {
-                case BoxCollider boxCollider:
-                    Gizmos.DrawCube(boxCollider.center, boxCollider.size);
-                    break;
-                case SphereCollider sphereCollider:
-                    Gizmos.DrawSphere(sphereCollider.center, sphereCollider.radius);
-                    break;
-            }
+            Gizmos.DrawIcon(transform.position, "Import", false);
         }
 
         protected virtual void Update()
@@ -207,7 +267,6 @@ namespace Innoactive.Creator.XRInteraction
                 CombineInstance combineInstance = new CombineInstance();
                 combineInstance.mesh = meshFilter.sharedMesh;
                 combineInstance.transform = meshFilter.transform.localToWorldMatrix;
-                
                 meshes.Add(combineInstance);
             }
 
@@ -237,11 +296,18 @@ namespace Innoactive.Creator.XRInteraction
             {
                 if (m_HoverTargets.Count == 0 && ShowHighlightObject)
                 {
-                    previewMaterial = HighlightMeshMaterial;
+                    activeMaterial = HighlightMeshMaterial;
                 } 
                 else if (m_HoverTargets.Count > 0 && showInteractableHoverMeshes)
                 {
-                    previewMaterial = ValidationMaterial;
+                    if (m_HoverTargets.All(CanSelect))
+                    {
+                        activeMaterial = ValidationMaterial;
+                    }
+                    else
+                    {
+                        activeMaterial = InvalidMaterial;
+                    }
                 }
             }
         }
@@ -251,10 +317,12 @@ namespace Innoactive.Creator.XRInteraction
         /// </summary>
         protected virtual void DrawHighlightMesh()
         {
-            if (previewMesh != null)
+            if (PreviewMesh != null)
             {
-                Matrix4x4 matrix = Matrix4x4.TRS(attachTransform.position, transform.rotation, transform.localScale);
-                Graphics.DrawMesh(previewMesh, matrix, previewMaterial, gameObject.layer);
+                for (int i = 0; i < PreviewMesh.subMeshCount; i++)
+                {
+                    Graphics.DrawMesh(PreviewMesh, attachTransform.localToWorldMatrix, activeMaterial, gameObject.layer, null, i);
+                }
             }
         }
 
@@ -318,8 +386,22 @@ namespace Innoactive.Creator.XRInteraction
                 return true;
             }
 
-            // Otherwise, normal routine.
-            return base.CanSelect(interactable);
+            // If this object cannot be selected, ignore it.
+            if (base.CanSelect(interactable) == false)
+            {
+                return false;
+            }
+            
+            // If one active validator does not allow this to be snapped, return false.
+            foreach (Validator validator in validators)
+            {
+                if (validator.isActiveAndEnabled && validator.Validate(interactable.gameObject) == false)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/Runtime/Interaction/SnapZonePreviewDrawer.cs
+++ b/Runtime/Interaction/SnapZonePreviewDrawer.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using UnityEngine;
+
+namespace Innoactive.Creator.XRInteraction
+{
+    /// <summary>
+    /// Draws a preview of SnapZone highlight.
+    /// </summary>
+    [ExecuteInEditMode]
+    public class SnapZonePreviewDrawer : MonoBehaviour
+    {
+        /// <summary>
+        /// The parent SnapZone.
+        /// </summary>
+        public SnapZone Parent { get; set; }
+        
+        private void Awake()
+        {
+            if (Application.isPlaying)
+            {
+                DestroyPreview();
+                DestroyImmediate(this);
+            }
+        }
+
+        private void Update()
+        {
+            if (Parent == null)
+            {
+                Parent = transform.parent.GetComponent<SnapZone>();
+                if (Parent == null)
+                {
+                    DestroyPreview();
+                }
+            }
+            
+            bool isPreviewing = gameObject.GetComponent<MeshFilter>() != null;
+            
+            if (Parent.ShowHighlightInEditor && Parent.PreviewMesh && isPreviewing == false)
+            {
+                MeshFilter meshFilter =  gameObject.AddComponent<MeshFilter>();
+                meshFilter.sharedMesh = Parent.PreviewMesh;
+                
+                MeshRenderer meshRenderer = gameObject.AddComponent<MeshRenderer>();
+                meshRenderer.material = Parent.HighlightMeshMaterial;
+            }
+            else if (Parent.ShowHighlightInEditor == false && isPreviewing)
+            {
+                DestroyPreview();
+            }
+        }
+
+        private void DestroyPreview()
+        {
+            MeshRenderer meshRenderer = GetComponent<MeshRenderer>();
+            if (meshRenderer != null)
+            {
+                DestroyImmediate(meshRenderer);
+            }
+            
+            MeshFilter filter = GetComponent<MeshFilter>();
+            if (filter != null)
+            {
+                DestroyImmediate(filter);
+            }
+            
+            DestroyImmediate(this);
+        }
+    }
+}

--- a/Runtime/Interaction/SnapZonePreviewDrawer.cs
+++ b/Runtime/Interaction/SnapZonePreviewDrawer.cs
@@ -12,53 +12,62 @@ namespace Innoactive.Creator.XRInteraction
         /// <summary>
         /// The parent SnapZone.
         /// </summary>
-        public SnapZone Parent { get; set; }
+        [SerializeField]
+        [HideInInspector]
+        private SnapZone parent;
+
+        private MeshFilter filter;
+        private MeshRenderer meshRenderer;
         
-        private void Awake()
+        private void Start()
         {
             if (Application.isPlaying)
             {
                 DestroyPreview();
                 DestroyImmediate(this);
+                return;
             }
+            
+            filter = gameObject.GetComponent<MeshFilter>();
+            if (filter == null)
+            {
+                filter = gameObject.AddComponent<MeshFilter>();
+            }
+
+            meshRenderer = gameObject.GetComponent<MeshRenderer>();
+            if (meshRenderer == null)
+            {
+                meshRenderer = gameObject.AddComponent<MeshRenderer>();
+            }
+            
+            if (parent == null)
+            {
+                parent = transform.parent.GetComponent<SnapZone>();
+                if (parent == null)
+                {
+                    DestroyPreview();
+                    return;
+                }
+            }
+
+            filter.sharedMesh = parent.PreviewMesh;
+            meshRenderer.material = parent.HighlightMeshMaterial;
         }
 
         private void Update()
         {
-            if (Parent == null)
-            {
-                Parent = transform.parent.GetComponent<SnapZone>();
-                if (Parent == null)
-                {
-                    DestroyPreview();
-                }
-            }
-            
-            bool isPreviewing = gameObject.GetComponent<MeshFilter>() != null;
-            
-            if (Parent.ShowHighlightInEditor && Parent.PreviewMesh && isPreviewing == false)
-            {
-                MeshFilter meshFilter =  gameObject.AddComponent<MeshFilter>();
-                meshFilter.sharedMesh = Parent.PreviewMesh;
-                
-                MeshRenderer meshRenderer = gameObject.AddComponent<MeshRenderer>();
-                meshRenderer.material = Parent.HighlightMeshMaterial;
-            }
-            else if (Parent.ShowHighlightInEditor == false && isPreviewing)
-            {
-                DestroyPreview();
-            }
+            meshRenderer.enabled = parent.ShowHighlightInEditor;
         }
 
         private void DestroyPreview()
         {
-            MeshRenderer meshRenderer = GetComponent<MeshRenderer>();
+            meshRenderer = gameObject.GetComponent<MeshRenderer>();
             if (meshRenderer != null)
             {
                 DestroyImmediate(meshRenderer);
             }
             
-            MeshFilter filter = GetComponent<MeshFilter>();
+            filter = gameObject.GetComponent<MeshFilter>();
             if (filter != null)
             {
                 DestroyImmediate(filter);

--- a/Runtime/Interaction/SnapZonePreviewDrawer.cs.meta
+++ b/Runtime/Interaction/SnapZonePreviewDrawer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 88ea78c93b844cc1b7f98cca70e8679c
+timeCreated: 1598435525


### PR DESCRIPTION
### Description
* Added Preview where and how the object will be snapped
* Normal created snapzones only allow to snap a specific TrainingSceneObject
* Fixed snapzone snapping position by adjusting the center of mass (always put it to 0,0,0 which).


**Fixes**: # (issue)
* TRNG-1047
* TRNG-1044

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### How Has This Been Tested?
by hand


**Test Configuration**:
To get this working you also have to checkout Basic interaction: Feature/validation for snapzones