### PR TITLE
fix: highlight object is now created rendering all sub meshes

### DIFF
--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -23,7 +23,7 @@ namespace Innoactive.Creator.XRInteraction
         [SerializeField]
         private bool isUsable = true;
 
-        private Rigidbody rigidbody;
+        private Rigidbody internalRigidbody;
         private XRSocketInteractor selectingSocket;
 
         /// <summary>
@@ -33,12 +33,12 @@ namespace Innoactive.Creator.XRInteraction
         {
             get
             {
-                if (rigidbody == null)
+                if (internalRigidbody == null)
                 {
-                    rigidbody = GetComponent<Rigidbody>();
+                    internalRigidbody = GetComponent<Rigidbody>();
                 }
                 
-                return rigidbody;
+                return internalRigidbody;
             }
         }
 


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The Snap Zone generator used to generate highlight objects with materials for the main mesh but not for the submeshes, this pr adds render support for those submeshes.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Create a snap zone from a snappable property with sub meshes.