### PR TITLE
fix: snap zone highlight creation ignores empty meshes now

### DIFF
--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -262,6 +262,11 @@ namespace Innoactive.Creator.XRInteraction
 
             foreach (SkinnedMeshRenderer skinnedMeshRenderer in ShownHighlightObject.GetComponentsInChildren<SkinnedMeshRenderer>())
             {
+                if (skinnedMeshRenderer.sharedMesh == null)
+                {
+                    continue;
+                }
+                
                 for (int i = 0; i < skinnedMeshRenderer.sharedMesh.subMeshCount; i++)
                 {
                     CombineInstance combineInstance = new CombineInstance();
@@ -275,6 +280,11 @@ namespace Innoactive.Creator.XRInteraction
             
             foreach (MeshFilter meshFilter in ShownHighlightObject.GetComponentsInChildren<MeshFilter>())
             {
+                if (meshFilter.sharedMesh == null)
+                {
+                    continue;
+                }
+
                 for (int i = 0; i < meshFilter.sharedMesh.subMeshCount; i++)
                 {
                     CombineInstance combineInstance = new CombineInstance();


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

This commit fixes a NullReferenceException which primarly happened when creating a highlight prefab of a snap zone that has other snap zones as children.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Create a snap zone of an object which has snap zones as children with the generator.