### PR TITLE
fix: fix HighlightProperty tests

### DIFF
--- a/Runtime/Properties/HighlightProperty.cs
+++ b/Runtime/Properties/HighlightProperty.cs
@@ -26,11 +26,16 @@ namespace Innoactive.Creator.XRInteraction.Properties
 
             if (Highlighter == null)
             {
-                Highlighter = GetComponent<InteractableHighlighter>();
+                Initialize();
             }
         }
         
         protected void Reset()
+        {
+            Initialize();
+        }
+
+        protected void Initialize()
         {
             InteractableObject ownInteractableObject = gameObject.GetComponent<InteractableObject>();
 


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The HighlightProperty tests were broken since MonoBehaviour.Reset() is not called during runtime.
It now initializes the Highlighter also in the MonoBehaviour.OnEnable() method,
when the MonoBehaviour.Reset() was not called before in editor.
### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Run all test cases and manually tested "fix it" buttons again.