### PR TITLE
chore: the xr prefab places the camera at its origin TRNG-1025

### DIFF
--- a/Resources/[XR_Setup].prefab
+++ b/Resources/[XR_Setup].prefab
@@ -1525,7 +1525,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7978014070532965571}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0, y: 0, z: -1.438}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 7469053385970781433}


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: Weird offset in the camera of the xr prefab.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->


Set the scene as a training scene and check the xr camera offset, it must be at 0,0,0