### PR TITLE
feat: nested snap zone is not grabbable by default

### DIFF
--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
 using Innoactive.Creator.BasicInteraction.Validation;
-using NAudio.SoundFont;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 

--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Collections.Generic;
 using Innoactive.Creator.BasicInteraction.Validation;
+using NAudio.SoundFont;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 
@@ -152,24 +153,22 @@ namespace Innoactive.Creator.XRInteraction
                 previewMesh = value;
             }
         }
-        
+
+        private Transform initialParent;
         private Material activeMaterial;
-
-        private List<Validator> validators = new List<Validator>();
-
         private Vector3 tmpCenterOfMass;
-
+        private List<Validator> validators = new List<Validator>();
+        
         protected override void Awake()
         {
             base.Awake();
-
-            validators = GetComponents<Validator>().ToList();
             
-            Collider triggerCollider = gameObject.GetComponentsInChildren<Collider>().FirstOrDefault(foundCollider => foundCollider.isTrigger);
-            if (triggerCollider == null)
+            validators = GetComponents<Validator>().ToList();
+
+            if (GetComponentsInChildren<Collider>()?.Any(foundCollider => foundCollider.isTrigger) == false)
             {
-                Debug.LogErrorFormat(gameObject, "The Snap Zone '{0}' does not have any trigger collider. "
-                    + "Make sure you have at least one collider with the property `Is Trigger` enabled.", gameObject.name);
+                Debug.LogError($"The Snap Zone '{name}' does not have any trigger collider. "
+                    + "Make sure you have at least one collider with the property `Is Trigger` enabled.", gameObject);
             }
 
             ShowHighlightObject = ShownHighlightObject != null;
@@ -180,12 +179,19 @@ namespace Innoactive.Creator.XRInteraction
             {
                 UpdateHighlightMeshFilterCache();
             }
+
+            initialParent = transform.parent;
+
+            if (initialParent != null)
+            {
+                transform.SetParent(null);
+            }
         }
 
         protected override void OnEnable()
         {
             base.OnEnable();
-            
+
             onSelectEnter.AddListener(OnAttach);
             onSelectExit.AddListener(OnDetach);
         }
@@ -218,6 +224,12 @@ namespace Innoactive.Creator.XRInteraction
 
         protected virtual void Update()
         {
+            if (initialParent != null)
+            {
+                transform.SetParent(initialParent);
+                initialParent = null;
+            }
+            
             if (socketActive && selectTarget == null)
             {
                 DrawHighlightMesh();


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

If a Snap Zone started a scene nested in an interactable object, the colliders of the snap zone were grabbable as an extension of the interactable object. This PR fixes this behavior.

**Note:** It is still possible to manually set the snap zones colliders as part of the interactable object. 

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Place a snap zone inside an interactable object, then run the scene an try to grab the interactable object by the snap zone, it should not be possible anymore.