### PR TITLE
fix: highlighting improved for interactables with multiple collider

### DIFF
--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -87,11 +87,29 @@ namespace Innoactive.Creator.XRInteraction
         protected override void Reset()
         {
             base.Reset();
-            
+
             // Sets the 'interactionLayerMask' to Default in order to not interact with Teleportation or UI rays.
             interactionLayerMask = 1;
         }
 
+        internal void OnTriggerEnter(Collider other)
+        {
+            SnapZone target = other.gameObject.GetComponent<SnapZone>();            
+            if (target != null && target.enabled && !IsInSocket)
+            {
+                target.AddHoveredInteractable(this);
+            }
+        }
+
+        internal void OnTriggerExit(Collider other)
+        {
+            SnapZone target = other.gameObject.GetComponent<SnapZone>();            
+            if (target != null && target.enabled)
+            {
+                target.RemoveHoveredInteractable(this);
+            }
+        }
+        
         /// <summary>
         /// Determines if this <see cref="InteractableObject"/> can be hovered by a given interactor.
         /// </summary>


### PR DESCRIPTION
### Description
Fixed the highlighting by running a own list which is not limited to a unique reference to the object. So each collider is handled separately and as long as there is at least one collider inside the snapzone its highlighted.


### Testing
The way I tested this was with the box from the XR-CKD Demo Project which contains multiple collider. I also figgured out the problem actually occured more often when one Collider was completely surrounded by another one.