### PR TITLE
fix: snap zones do not lose validation material anymore

### DIFF
--- a/Editor/SnapZone/SnapZoneSettings.cs
+++ b/Editor/SnapZone/SnapZoneSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using UnityEditor;
 using UnityEngine;
@@ -121,16 +122,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
         {
             if (highlightMaterial == null)
             {
-                highlightMaterial = CreateMaterial();
-                highlightMaterial.name = "SnapZoneHighlightMaterial";
-
-                if (Directory.Exists(MaterialsPath) == false)
-                {
-                    Directory.CreateDirectory(MaterialsPath);
-                }
-
-                AssetDatabase.CreateAsset(highlightMaterial, $"{MaterialsPath}/{highlightMaterial.name}.mat");
-                AssetDatabase.Refresh();
+                highlightMaterial = UseDefaultMaterial("SnapZoneHighlightMaterial");
             }
                 
             highlightMaterial.color = HighlightColor;
@@ -141,16 +133,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
         {
             if (invalidMaterial == null)
             {
-                invalidMaterial = CreateMaterial();
-                invalidMaterial.name = "SnapZoneInvalidMaterial";
-
-                if (Directory.Exists(MaterialsPath) == false)
-                {
-                    Directory.CreateDirectory(MaterialsPath);
-                }
-
-                AssetDatabase.CreateAsset(invalidMaterial, $"{MaterialsPath}/{invalidMaterial.name}.mat");
-                AssetDatabase.Refresh();
+                invalidMaterial = UseDefaultMaterial("SnapZoneInvalidMaterial");
             }
                 
             invalidMaterial.color = InvalidColor;
@@ -161,20 +144,39 @@ namespace Innoactive.CreatorEditor.XRInteraction
         {
             if (validationMaterial == null)
             {
-                validationMaterial = CreateMaterial();
-                validationMaterial.name = "SnapZoneValidationMaterial";
-
-                if (Directory.Exists(MaterialsPath) == false)
-                {
-                    Directory.CreateDirectory(MaterialsPath);
-                }
-
-                AssetDatabase.CreateAsset(validationMaterial, $"{MaterialsPath}/{validationMaterial.name}.mat");
-                AssetDatabase.Refresh();
+                validationMaterial = UseDefaultMaterial("SnapZoneValidationMaterial");
             }
                 
             validationMaterial.color = ValidationColor;
             return validationMaterial;
+        }
+
+        private Material UseDefaultMaterial(string materialName)
+        {
+            if (Directory.Exists(MaterialsPath) == false)
+            {
+                Directory.CreateDirectory(MaterialsPath);
+            }
+            
+            string filePath = $"{MaterialsPath}/{materialName}.mat";
+
+            if (File.Exists(filePath))
+            {
+                try
+                {
+                    return (Material)AssetDatabase.LoadAssetAtPath(filePath, typeof(Material));
+                }
+                catch (Exception)
+                {
+                    Debug.LogError($"Material at '{filePath}' is corrupted or not a material. A new one is created in the same file path.");
+                }
+            }
+
+            Material material = CreateMaterial();
+            material.name = materialName;
+            AssetDatabase.CreateAsset(material, filePath);
+            AssetDatabase.Refresh();
+            return material;
         }
 
         private Material CreateMaterial()


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

When the snap zone settings were lost, a new material was created. It overrid the old default material. This lead to losing the validation material in previous configured snap zones because the old material was removed.

**Fixes**: [TRNG-1070](https://jira.innoactive.de/browse/TRNG-1070)

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
1. Create a snap zone with the generator
2. Play scene
3. Stop scene
4. Create new snap zones with the generator
5. Sporadically the previous (old) snap zones lost the validation material
6. Somehow sometimes the settings were set to null and thus a new validation material was created which overrid the old material. Thus all old snap zones lost their validation material.

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules