### PR TITLE
Controllers do not stop interacting after a touch condition

### DIFF
--- a/Editor/Properties/SnappablePropertyEditor.cs
+++ b/Editor/Properties/SnappablePropertyEditor.cs
@@ -15,7 +15,7 @@ namespace Innoactive.CreatorEditor.XRInteraction
     /// Custom inspector for <see cref="SnappableProperty"/>, adding a button to create <see cref="Innoactive.Creator.XRInteraction.SnapZone"/>s automatically.
     /// </summary>
     [CustomEditor(typeof(SnappableProperty))]
-    public class SnappablePropertyEditor : Editor
+    internal class SnappablePropertyEditor : Editor
     {
         private const string PrefabPath = "Assets/Resources/SnapZones/Prefabs";
 

--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -147,6 +147,7 @@ namespace Innoactive.Creator.XRInteraction
         protected override void OnSelectEnter(XRBaseInteractor interactor)
         {
             base.OnSelectEnter(interactor);
+            
             if (IsInSocket == false)
             {
                 XRSocketInteractor socket = interactor.GetComponent<XRSocketInteractor>();
@@ -194,43 +195,23 @@ namespace Innoactive.Creator.XRInteraction
                 base.OnDeactivate(interactor);
             }
         }
-        
-        internal void SimulateHoverEnter(XRBaseInteractor interactor)
-        {
-            OnHoverEnter(interactor);
-        }
-        
-        internal void SimulateHoverExit(XRBaseInteractor interactor)
-        {
-            OnHoverExit(interactor);
-        }
-        
+
         private IEnumerator StopInteractingForOneFrame()
         {
-            List<XRBaseInteractor> interactors = new List<XRBaseInteractor>(hoveringInteractors);
-            
-            if (interactors.Contains(selectingInteractor) == false)
+            bool wasTouchable = isTouchable, wasGrabbable = isGrabbable, wasUsable = isUsable;
+            isTouchable = isGrabbable = isUsable = false;
+
+            if (selectingSocket != null)
             {
-                interactors.Add(selectingInteractor);
+                SnapZone snapZone = selectingSocket as SnapZone;
+                snapZone.ForceUnselect();
             }
             
-            foreach (XRBaseInteractor interactor in interactors.Where(interactor => interactor != null))
-            {
-                if (interactor.GetComponent<XRController>() != null)
-                {
-                    interactor.enableInteractions = false;
-                }
-            }
+            yield return new WaitUntil(() => hoveringInteractors.Count == 0 && selectingInteractor == null);
             
-            yield return new WaitUntil(() => isHovered == false && (isSelected == false || IsInSocket));
-            
-            foreach (XRBaseInteractor interactor in interactors.Where(interactor => interactor != null))
-            {
-                if (interactor.GetComponent<XRController>() != null)
-                {
-                    interactor.enableInteractions = true;
-                }
-            }
+            isTouchable = wasTouchable;
+            isGrabbable = wasGrabbable;
+            isUsable = wasUsable;
         }
     }
 }

--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -195,6 +195,16 @@ namespace Innoactive.Creator.XRInteraction
             }
         }
         
+        internal void SimulateHoverEnter(XRBaseInteractor interactor)
+        {
+            OnHoverEnter(interactor);
+        }
+        
+        internal void SimulateHoverExit(XRBaseInteractor interactor)
+        {
+            OnHoverExit(interactor);
+        }
+        
         private IEnumerator StopInteractingForOneFrame()
         {
             List<XRBaseInteractor> interactors = new List<XRBaseInteractor>(hoveringInteractors);

--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -391,11 +391,8 @@ namespace Innoactive.Creator.XRInteraction
             }
             else
             {
-                Debug.LogWarningFormat(interactable.gameObject, 
-                    "Interactable '{0}' is not selectable by Snap Zone '{1}'. "
-                    + "(Maybe the Interaction Layer Masks settings are not correct or the interactable object is locked?)", 
-                    interactable.gameObject.name, 
-                    gameObject.name);
+                Debug.LogWarning($"Interactable '{interactable.name}' is not selectable by Snap Zone '{name}'. "
+                    + $"(Maybe the Interaction Layer Masks settings are not correct or the interactable object is locked?)", interactable.gameObject);
             }
         }
 

--- a/Runtime/Properties/GrabbableProperty.cs
+++ b/Runtime/Properties/GrabbableProperty.cs
@@ -60,7 +60,7 @@ namespace Innoactive.Creator.XRInteraction.Properties
         protected void Reset()
         {
             Interactable.IsGrabbable = true;
-            gameObject.GetComponent<Rigidbody>().isKinematic = false;
+            GetComponent<Rigidbody>().isKinematic = false;
         }
 
         private void HandleXRGrabbed(XRBaseInteractor interactor)

--- a/Runtime/Properties/TouchableProperty.cs
+++ b/Runtime/Properties/TouchableProperty.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 using Innoactive.Creator.Core.Properties;
@@ -85,14 +86,6 @@ namespace Innoactive.Creator.XRInteraction.Properties
         protected override void InternalSetLocked(bool lockState)
         {
             Interactable.IsTouchable = lockState == false;
-            
-            if (IsBeingTouched)
-            {
-                if (lockState)
-                {
-                    Interactable.ForceStopInteracting();
-                }
-            }
         }
 
         /// <inheritdoc />
@@ -100,7 +93,17 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             if (IsBeingTouched)
             {
-                Interactable.ForceStopInteracting();
+                List<XRBaseInteractor> interactors = Interactable.hoveringInteractors;
+
+                foreach (XRBaseInteractor interactor in interactors)
+                {
+                    Interactable.SimulateHoverExit(interactor);
+                }
+                
+                foreach (XRBaseInteractor interactor in interactors)
+                {
+                    Interactable.SimulateHoverEnter(interactor);
+                }
             }
             else
             {

--- a/Runtime/Properties/TouchableProperty.cs
+++ b/Runtime/Properties/TouchableProperty.cs
@@ -93,17 +93,7 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             if (IsBeingTouched)
             {
-                List<XRBaseInteractor> interactors = Interactable.hoveringInteractors;
-
-                foreach (XRBaseInteractor interactor in interactors)
-                {
-                    Interactable.SimulateHoverExit(interactor);
-                }
-                
-                foreach (XRBaseInteractor interactor in interactors)
-                {
-                    Interactable.SimulateHoverEnter(interactor);
-                }
+                Interactable.ForceStopInteracting();
             }
             else
             {


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: If after a touch condition there is a disabled behavior that disables the same object that was previously touched, the controller that touched the object stops interacting (no more touch or grab), this can be reverted after the user uses that controller for teleporting or to show the UI ray controller.

### Type of change
<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Make a course where you have to touch something, the next step right after the touch condition, disable the very same object (like in CKD when the user has to touch the button on the screen), then try to touch or grab another object.

### Known issues

If the same procedure is also applied for a grab condition, the controller also gets disabled. That is another issue that will have its own ticket.