### PR TITLE
fix: snappable will be properly snapped to snapzones when thrown

### DIFF
--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -95,7 +95,7 @@ namespace Innoactive.Creator.XRInteraction
         internal void OnTriggerEnter(Collider other)
         {
             SnapZone target = other.gameObject.GetComponent<SnapZone>();            
-            if (target != null && target.enabled && !IsInSocket)
+            if (target != null && target.enabled && !IsInSocket && isSelected)
             {
                 target.AddHoveredInteractable(this);
             }

--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -361,9 +361,14 @@ namespace Innoactive.Creator.XRInteraction
 
         private void CheckForReleasedHoverTargets()
         {
+            if (selectTarget != null)
+            {
+                return;
+            }
+            
             foreach (XRBaseInteractable target in hoverTargets)
             {
-                if (m_HoverTargets.Contains(target) || target.isSelected || selectTarget != null)
+                if (m_HoverTargets.Contains(target) || target.isSelected)
                 {
                     continue;
                 }


### PR DESCRIPTION
### Description
throwing things into the snapzone made it force snap before the normal snap behavior was triggered. Fixed by only force snapping when the object was, beforehand grabbed.