### PR TITLE
fix: force select properly attaches object now

### DIFF
--- a/Runtime/Interaction/InteractableObject.cs
+++ b/Runtime/Interaction/InteractableObject.cs
@@ -159,6 +159,11 @@ namespace Innoactive.Creator.XRInteraction
             OnActivate(selectingInteractor);
         }
 
+        internal void ForceSelectEnter(XRBaseInteractor interactor)
+        {
+            OnSelectEnter(interactor);
+        }
+        
         /// <summary>This method is called by the interaction manager 
         /// when the interactor first initiates selection of an interactable.</summary>
         /// <param name="interactor">Interactor that is initiating the selection.</param>

--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -428,12 +428,13 @@ namespace Innoactive.Creator.XRInteraction
 
             if (interactable.IsSelectableBy(this))
             {
+                OnSelectEnter(interactable);
+                
                 if (interactable is InteractableObject interactableObject)
                 {
                     interactableObject.ForceSelectEnter(this);
                 }
                 
-                OnSelectEnter(interactable);
                 interactable.transform.position = attachTransform.position;
                 interactable.transform.rotation = attachTransform.rotation;
                 ForceSelectTarget = interactable;

--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -428,6 +428,11 @@ namespace Innoactive.Creator.XRInteraction
 
             if (interactable.IsSelectableBy(this))
             {
+                if (interactable is InteractableObject interactableObject)
+                {
+                    interactableObject.ForceSelectEnter(this);
+                }
+                
                 OnSelectEnter(interactable);
                 interactable.transform.position = attachTransform.position;
                 interactable.transform.rotation = attachTransform.rotation;


### PR DESCRIPTION
### Description
To properly select/snap an object the object snapped also have to call OnSelectEnter.

to test:
Step1: Snap an object do a snapzone
Step2: do something else

=> run the course, fast forward to step2, see if the snapped object moves when the snapzone is moved.