### PR TITLE
fix: highlighted objects recover their renderer when they become disabled

### DIFF
--- a/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
@@ -72,6 +72,7 @@ namespace Innoactive.Creator.XRInteraction
         [SerializeField]
         private Color useHighlightColor = new Color32(0, 255, 0, 50);
 
+        private bool isBeingHighlighted;
         private Material colorTouchMaterial;
         private Material colorGrabMaterial;
         private Material colorUseMaterial;
@@ -98,6 +99,14 @@ namespace Innoactive.Creator.XRInteraction
 
         private void OnDisable()
         {
+            if (isBeingHighlighted)
+            {
+                ReenableRenderers(cachedSkinnedRenderers);
+                ReenableRenderers(cachedMeshRenderers);
+                
+                externalHighlights.Clear();
+            }
+            
             interactableObject.onFirstHoverEnter.RemoveListener(OnTouched);
             interactableObject.onSelectEnter.RemoveListener(OnGrabbed);
             interactableObject.onSelectExit.RemoveListener(OnReleased);
@@ -212,6 +221,7 @@ namespace Innoactive.Creator.XRInteraction
 
             while (shouldContinueHighlighting())
             {
+                isBeingHighlighted = true;
                 DisableRenders(cachedSkinnedRenderers);
                 DisableRenders(cachedMeshRenderers);
 
@@ -228,6 +238,7 @@ namespace Innoactive.Creator.XRInteraction
                 yield return null;
             }
 
+            isBeingHighlighted = false;
             ReenableRenderers(cachedSkinnedRenderers);
             ReenableRenderers(cachedMeshRenderers);
 


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: Objects that were disabled while being highlighted used to lose their renderer, this was only noticeable when they were enabled again.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->


Create a course with 3 steps: 

- Step 1 highlights an object.
- Step 2 disables that object.
- Step 3 enables it again.