### PR TITLE
fix: snap zones are not locked while detached from their parent.

### DIFF
--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -182,12 +182,7 @@ namespace Innoactive.Creator.XRInteraction
                 UpdateHighlightMeshFilterCache();
             }
 
-            initialParent = transform.parent;
-
-            if (initialParent != null)
-            {
-                transform.SetParent(null);
-            }
+            DetachParent();
         }
 
         internal void AddHoveredInteractable(XRBaseInteractable interactable)
@@ -217,6 +212,7 @@ namespace Innoactive.Creator.XRInteraction
         {
             base.OnDisable();
             
+            AttachParent();
             hoverTargets.Clear();
             
             onSelectEnter.RemoveListener(OnAttach);
@@ -235,6 +231,25 @@ namespace Innoactive.Creator.XRInteraction
             Rigidbody rigid = interactable.gameObject.GetComponent<Rigidbody>();
             rigid.centerOfMass = tmpCenterOfMass;
         }
+        
+        private void DetachParent()
+        {
+            initialParent = transform.parent;
+            
+            if (initialParent != null)
+            {
+                transform.SetParent(null);
+            }
+        }
+
+        private void AttachParent()
+        {
+            if (initialParent != null)
+            {
+                transform.SetParent(initialParent);
+                initialParent = null;
+            }
+        }
 
         private void OnDrawGizmos()
         {
@@ -243,11 +258,7 @@ namespace Innoactive.Creator.XRInteraction
 
         protected virtual void Update()
         {
-            if (initialParent != null)
-            {
-                transform.SetParent(initialParent);
-                initialParent = null;
-            }
+            AttachParent();
             
             if (socketActive && selectTarget == null)
             {


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: Snap zones were locked before they were reparented.
Detaching and reattaching is made so if the parent is an interactable object then it does not consider snap zones colliders as valid colliders for it.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Try CKD