### PR TITLE
fix: batched meshes are prevented to be highlighted

### DIFF
--- a/Editor/Interaction/InteractableHighlighterEditor.cs
+++ b/Editor/Interaction/InteractableHighlighterEditor.cs
@@ -74,6 +74,9 @@ namespace Innoactive.CreatorEditor.XRInteraction
 
         private void OnEnable()
         {
+            InteractableHighlighter highlighter = target as InteractableHighlighter;
+            highlighter.ForceRefreshCachedRenderers();
+            
             onTouchHighlighting = new HighlightCase(serializedObject, "On Touch Highlight", "touchHighlightColor", "touchHighlightMaterial", "allowOnTouchHighlight", true);
             onGrabHighlighting = new HighlightCase(serializedObject, "On Grab Highlight", "grabHighlightColor", "grabHighlightMaterial", "allowOnGrabHighlight", false);
             onUseHighlighting = new HighlightCase(serializedObject, "On Use Highlight", "useHighlightColor", "useHighlightMaterial", "allowOnUseHighlight", false);

--- a/Runtime/AssemblyAttributes.cs
+++ b/Runtime/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Innoactive.CreatorEditor.XRInteraction")]

--- a/Runtime/AssemblyAttributes.cs.meta
+++ b/Runtime/AssemblyAttributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0af65623b2e21481f8a378c64a5cfd93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
@@ -331,6 +331,11 @@ namespace Innoactive.Creator.XRInteraction
         internal void ForceRefreshCachedRenderers()
         {
             ReenableRenderers();
+
+            if (Application.isPlaying && gameObject.isStatic)
+            {
+                return;
+            }
             
             renderers = default;
             previewMesh = null;

--- a/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
@@ -72,16 +72,23 @@ namespace Innoactive.Creator.XRInteraction
         [SerializeField]
         private Color useHighlightColor = new Color32(0, 255, 0, 50);
 
-        private bool isBeingHighlighted;
         private Material colorTouchMaterial;
         private Material colorGrabMaterial;
         private Material colorUseMaterial;
 
         private Dictionary<string, bool> externalHighlights = new Dictionary<string, bool>();
         private InteractableObject interactableObject;
-        private SkinnedMeshRenderer[] cachedSkinnedRenderers = {};
-        private MeshRenderer[] cachedMeshRenderers = {};
-        private MeshFilter[] cachedMeshFilters = {};
+        
+        [SerializeField]
+        private Renderer[] renderers = {};
+        
+        [SerializeField]
+        private Mesh previewMesh = null;
+
+        private void Reset()
+        {
+            RefreshCachedRenderers();
+        }
 
         private void OnEnable()
         {
@@ -99,19 +106,11 @@ namespace Innoactive.Creator.XRInteraction
 
         private void OnDisable()
         {
-            if (isBeingHighlighted)
-            {
-                ReenableRenderers(cachedSkinnedRenderers);
-                ReenableRenderers(cachedMeshRenderers);
-                
-                externalHighlights.Clear();
-            }
-            
-            interactableObject.onFirstHoverEnter.RemoveListener(OnTouched);
-            interactableObject.onSelectEnter.RemoveListener(OnGrabbed);
-            interactableObject.onSelectExit.RemoveListener(OnReleased);
-            interactableObject.onActivate.RemoveListener(OnUsed);
-            interactableObject.onDeactivate.RemoveListener(OnUnused);
+            interactableObject?.onFirstHoverEnter.RemoveListener(OnTouched);
+            interactableObject?.onSelectEnter.RemoveListener(OnGrabbed);
+            interactableObject?.onSelectExit.RemoveListener(OnReleased);
+            interactableObject?.onActivate.RemoveListener(OnUsed);
+            interactableObject?.onDeactivate.RemoveListener(OnUnused);
         }
 
         private void OnValidate()
@@ -138,6 +137,11 @@ namespace Innoactive.Creator.XRInteraction
         /// <remarks>Every highlight requires an ID to avoid duplications.</remarks>
         public void StartHighlighting(string highlightID, Material highlightMaterial)
         {
+            if (CanObjectBeHighlighted() == false)
+            {
+                return;
+            }
+            
             if (externalHighlights.ContainsKey(highlightID) == false)
             {
                 bool shouldContinueHighlighting = true;
@@ -152,6 +156,11 @@ namespace Innoactive.Creator.XRInteraction
         /// <remarks>Every highlight requires an ID to avoid duplications.</remarks>
         public void StartHighlighting(string highlightID, Color highlightColor)
         {
+            if (CanObjectBeHighlighted() == false)
+            {
+                return;
+            }
+            
             if (externalHighlights.ContainsKey(highlightID) == false)
             {
                 bool shouldContinueHighlighting = true;
@@ -167,6 +176,11 @@ namespace Innoactive.Creator.XRInteraction
         /// <remarks>Every highlight requires an ID to avoid duplications.</remarks>
         public void StartHighlighting(string highlightID, Texture highlightTexture)
         {
+            if (CanObjectBeHighlighted() == false)
+            {
+                return;
+            }
+            
             if (externalHighlights.ContainsKey(highlightID) == false)
             {
                 bool shouldContinueHighlighting = true;
@@ -214,33 +228,20 @@ namespace Innoactive.Creator.XRInteraction
 
         private IEnumerator Highlight(Material highlightMaterial, Func<bool> shouldContinueHighlighting, string highlightID = "")
         {
-            if (cachedSkinnedRenderers.Length == 0 && cachedMeshRenderers.Length == 0)
+            if (previewMesh == null || renderers.Any() == false)
             {
                 RefreshCachedRenderers();
             }
-
+            
             while (shouldContinueHighlighting())
             {
-                isBeingHighlighted = true;
-                DisableRenders(cachedSkinnedRenderers);
-                DisableRenders(cachedMeshRenderers);
-
-                foreach (SkinnedMeshRenderer skinnedRenderer in cachedSkinnedRenderers)
-                {
-                    DrawHighlightedObject(skinnedRenderer.sharedMesh, skinnedRenderer, highlightMaterial);
-                }
-
-                foreach (MeshFilter meshFilter in cachedMeshFilters)
-                {
-                    DrawHighlightedObject(meshFilter.sharedMesh, meshFilter, highlightMaterial);
-                }
+                DisableRenders();
+                Graphics.DrawMesh(previewMesh, transform.localToWorldMatrix, highlightMaterial, gameObject.layer, null);
 
                 yield return null;
             }
 
-            isBeingHighlighted = false;
-            ReenableRenderers(cachedSkinnedRenderers);
-            ReenableRenderers(cachedMeshRenderers);
+            ReenableRenderers();
 
             if (string.IsNullOrEmpty(highlightID) == false && externalHighlights.ContainsKey(highlightID))
             {
@@ -268,7 +269,6 @@ namespace Innoactive.Creator.XRInteraction
                     highlightMaterial = colorTouchMaterial;
                 }
 
-                RefreshCachedRenderers();
                 StartCoroutine(Highlight(highlightMaterial, ShouldHighlightTouching));
             }
         }
@@ -321,19 +321,115 @@ namespace Innoactive.Creator.XRInteraction
             }
         }
 
+        internal void ForceRefreshCachedRenderers()
+        {
+            renderers = default;
+            previewMesh = null;
+            RefreshCachedRenderers();
+        }
+
         private void RefreshCachedRenderers()
         {
-            if (cachedSkinnedRenderers.Any() && cachedSkinnedRenderers.First().enabled == false || cachedMeshRenderers.Any() && cachedMeshRenderers.First().enabled == false)
+            if (previewMesh != null && renderers.Any())
             {
                 return;
             }
 
-            cachedSkinnedRenderers = GetComponentsInChildren<SkinnedMeshRenderer>().Where(meshRenderer => meshRenderer.enabled).ToArray();
-            cachedMeshRenderers = GetComponentsInChildren<MeshRenderer>().Where(meshRenderer => meshRenderer.enabled).ToArray();
-            cachedMeshFilters = cachedMeshRenderers.Select(meshRenderer => meshRenderer.GetComponent<MeshFilter>()).ToArray();
+            renderers = GetComponentsInChildren<SkinnedMeshRenderer>()
+                .Where(skinnedMeshRenderer => skinnedMeshRenderer.gameObject.activeInHierarchy && skinnedMeshRenderer.enabled)
+                .Concat<Renderer>(GetComponentsInChildren<MeshRenderer>()
+                    .Where(meshRenderer => meshRenderer.gameObject.activeInHierarchy && meshRenderer.enabled)).ToArray();
+
+            if (renderers == null || renderers.Any() == false)
+            {
+                throw new NullReferenceException($"{name} has no renderers to be highlighted.");
+            }
+
+            GeneratePreviewMesh();
         }
 
-        private void DisableRenders(IEnumerable<Renderer> renderers)
+        private void GeneratePreviewMesh()
+        {
+            bool isAnyPartOfStaticBatch = false;
+            List<CombineInstance> meshes = new List<CombineInstance>();
+
+            foreach (Renderer renderer in renderers)
+            {
+                Type renderType = renderer.GetType();
+                
+                if (renderType == typeof(MeshRenderer))
+                {
+                    MeshFilter meshFilter = renderer.GetComponent<MeshFilter>();
+                    
+                    if (meshFilter.sharedMesh == null)
+                    {
+                        continue;
+                    }
+
+                    if (renderer.isPartOfStaticBatch)
+                    {
+                        isAnyPartOfStaticBatch = true;
+                    }
+
+                    for (int i = 0; i < meshFilter.sharedMesh.subMeshCount; i++)
+                    {
+                        CombineInstance combineInstance = new CombineInstance
+                        {
+                            subMeshIndex = i,
+                            mesh = meshFilter.sharedMesh,
+                            transform = Matrix4x4.identity
+                        };
+
+                        meshes.Add(combineInstance);
+                    }
+                }
+                else if (renderType == typeof(SkinnedMeshRenderer))
+                {
+                    SkinnedMeshRenderer skinnedMeshRenderer = renderer as SkinnedMeshRenderer;
+                    
+                    if (skinnedMeshRenderer.sharedMesh == null)
+                    {
+                        continue;
+                    }
+                    
+                    if (renderer.isPartOfStaticBatch)
+                    {
+                        isAnyPartOfStaticBatch = true;
+                    }
+
+                    for (int i = 0; i < skinnedMeshRenderer.sharedMesh.subMeshCount; i++)
+                    {
+                        CombineInstance combineInstance = new CombineInstance
+                        {
+                            subMeshIndex = i,
+                            mesh = skinnedMeshRenderer.sharedMesh,
+                            transform = Matrix4x4.identity
+                        };
+
+                        meshes.Add(combineInstance);
+                    }
+                }
+            }
+
+            if (isAnyPartOfStaticBatch)
+            {
+                throw new NullReferenceException($"{name} is marked as 'Batching Static', no preview mesh to be highlighted could be generated at runtime.\n" +
+                                                 $"In order to fix this issue, please either remove the static flag of this GameObject or simply " +
+                                                 $"select it in edit mode so a preview mesh could be generated and cached.");
+            } 
+            
+            if (meshes.Any())
+            {
+                previewMesh = new Mesh();
+                previewMesh.CombineMeshes(meshes.ToArray());
+            }
+            else
+            {
+                throw new NullReferenceException($"{name} has no valid meshes to be highlighted.");
+            }
+        }
+
+        private void DisableRenders()
         {
             foreach (Renderer activeRenderer in renderers)
             {
@@ -341,23 +437,11 @@ namespace Innoactive.Creator.XRInteraction
             }
         }
 
-        private void ReenableRenderers(IEnumerable<Renderer> renderers)
+        private void ReenableRenderers()
         {
             foreach (Renderer renderer in renderers)
             {
                 renderer.enabled = true;
-            }
-        }
-
-        private void DrawHighlightedObject(Mesh mesh, Component renderer, Material material)
-        {
-            LayerMask layerMask = renderer.gameObject.layer;
-            Transform rendersTransform = renderer.transform;
-            Matrix4x4 matrix = Matrix4x4.TRS(rendersTransform.position, rendersTransform.rotation, rendersTransform.lossyScale);
-
-            for (int i = 0; i < mesh.subMeshCount; i++)
-            {
-                Graphics.DrawMesh(mesh, matrix, material, layerMask, null, i);
             }
         }
 
@@ -424,6 +508,23 @@ namespace Innoactive.Creator.XRInteraction
             }
 
             return new Material(shader);
+        }
+
+        private bool CanObjectBeHighlighted()
+        {
+            if (enabled == false)
+            {
+                Debug.LogError($"{GetType().Name} component is disabled for {name} and can not be highlighted.", gameObject);
+                return false;
+            }
+            
+            if (gameObject.activeInHierarchy == false)
+            {
+                Debug.LogError($"{name} is disabled and can not be highlighted.", gameObject);
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
@@ -330,8 +330,11 @@ namespace Innoactive.Creator.XRInteraction
 
         internal void ForceRefreshCachedRenderers()
         {
+            ReenableRenderers();
+            
             renderers = default;
             previewMesh = null;
+            
             RefreshCachedRenderers();
         }
 

--- a/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Highlighters/InteractableHighlighter.cs
@@ -72,6 +72,7 @@ namespace Innoactive.Creator.XRInteraction
         [SerializeField]
         private Color useHighlightColor = new Color32(0, 255, 0, 50);
 
+        private bool isBeingHighlighted;
         private Material colorTouchMaterial;
         private Material colorGrabMaterial;
         private Material colorUseMaterial;
@@ -106,6 +107,12 @@ namespace Innoactive.Creator.XRInteraction
 
         private void OnDisable()
         {
+            if (isBeingHighlighted)
+            {
+                ReenableRenderers();
+                externalHighlights.Clear();
+            }
+            
             interactableObject?.onFirstHoverEnter.RemoveListener(OnTouched);
             interactableObject?.onSelectEnter.RemoveListener(OnGrabbed);
             interactableObject?.onSelectExit.RemoveListener(OnReleased);
@@ -435,6 +442,8 @@ namespace Innoactive.Creator.XRInteraction
             {
                 activeRenderer.enabled = false;
             }
+            
+            isBeingHighlighted = true;
         }
 
         private void ReenableRenderers()
@@ -443,6 +452,8 @@ namespace Innoactive.Creator.XRInteraction
             {
                 renderer.enabled = true;
             }
+            
+            isBeingHighlighted = false;
         }
 
         private bool ShouldHighlightTouching()

--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -130,6 +130,7 @@ namespace Innoactive.Creator.XRInteraction
         /// </summary>
         protected XRBaseInteractable ForceSelectTarget { get; set; }
         
+        [SerializeField]
         private Mesh previewMesh;
         
         /// <summary>
@@ -156,9 +157,7 @@ namespace Innoactive.Creator.XRInteraction
         private Transform initialParent;
         private Material activeMaterial;
         private Vector3 tmpCenterOfMass;
-        
         private List<Validator> validators = new List<Validator>();
-        
         private List<XRBaseInteractable> hoverTargets = new List<XRBaseInteractable>();
         
         protected override void Awake()
@@ -329,11 +328,13 @@ namespace Innoactive.Creator.XRInteraction
 
                 for (int i = 0; i < meshFilter.sharedMesh.subMeshCount; i++)
                 {
-                    CombineInstance combineInstance = new CombineInstance();
-                    combineInstance.mesh = meshFilter.sharedMesh;
-                    combineInstance.subMeshIndex = i;
-                    combineInstance.transform = meshFilter.transform.localToWorldMatrix;
-                
+                    CombineInstance combineInstance = new CombineInstance
+                    {
+                        subMeshIndex = i,
+                        mesh = meshFilter.sharedMesh,
+                        transform = Matrix4x4.identity
+                    };
+
                     meshes.Add(combineInstance);
                 }
             }
@@ -411,10 +412,7 @@ namespace Innoactive.Creator.XRInteraction
         {
             if (PreviewMesh != null)
             {
-                for (int i = 0; i < PreviewMesh.subMeshCount; i++)
-                {
-                    Graphics.DrawMesh(PreviewMesh, attachTransform.localToWorldMatrix, activeMaterial, gameObject.layer, null, i);
-                }
+                Graphics.DrawMesh(PreviewMesh, attachTransform.localToWorldMatrix, activeMaterial, gameObject.layer, null);
             }
         }
 

--- a/Tests/Runtime/HighlightObjectTests.cs
+++ b/Tests/Runtime/HighlightObjectTests.cs
@@ -42,7 +42,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         public IEnumerator CreateHighlightProperty()
         {
             // Given an empty GameObject.
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             
             Assert.That(interactable.GetComponent<InteractableObject>() == null);
             Assert.That(interactable.GetComponent<InteractableHighlighter>() == null);
@@ -73,7 +74,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         public IEnumerator CreateDummyHighlightProperty()
         {
             // Given an empty GameObject.
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             
             Assert.That(interactable.GetComponent<InteractableObject>() == null);
             Assert.That(interactable.GetComponent<InteractableHighlighter>() == null);
@@ -105,7 +107,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         {
             // Given a HighlightObjectBehavior with a HighlightProperty in a linear chapter.
             Color highlightColor = Color.yellow;
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             DummyHighlightProperty highlightProperty = interactable.AddComponent<DummyHighlightProperty>();
             HighlightObjectBehavior highlightBehavior = new HighlightObjectBehavior(highlightProperty, highlightColor);
         
@@ -164,7 +167,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         
             RuntimeConfigurator.Configuration = testRuntimeConfiguration;
             
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             DummyHighlightProperty highlightProperty = interactable.AddComponent<DummyHighlightProperty>();
             HighlightObjectBehavior highlightBehavior = new HighlightObjectBehavior(highlightProperty, highlightColor);
             highlightBehavior.Configure(testRuntimeConfiguration.Modes.CurrentMode);
@@ -185,7 +189,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         {
             // Given a HighlightObjectBehavior with a HighlightProperty.
             Color highlightColor = Color.cyan;
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             DummyHighlightProperty highlightProperty = interactable.AddComponent<DummyHighlightProperty>();
             HighlightObjectBehavior highlightBehavior = new HighlightObjectBehavior(highlightProperty, highlightColor);
         
@@ -203,7 +208,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         {
             // Given a HighlightObjectBehavior with a HighlightProperty.
             Color highlightColor = Color.red;
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             DummyHighlightProperty highlightProperty = interactable.AddComponent<DummyHighlightProperty>();
             HighlightObjectBehavior highlightBehavior = new HighlightObjectBehavior(highlightProperty, highlightColor);
         
@@ -222,7 +228,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         {
             // Given a HighlightObjectBehavior with a HighlightProperty.
             Color highlightColor = Color.white;
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             DummyHighlightProperty highlightProperty = interactable.AddComponent<DummyHighlightProperty>();
             HighlightObjectBehavior highlightBehavior = new HighlightObjectBehavior(highlightProperty, highlightColor);
         
@@ -242,7 +249,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         {
             // Given a HighlightObjectBehavior with a HighlightProperty.
             Color highlightColor = Color.blue;
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             DummyHighlightProperty highlightProperty = interactable.AddComponent<DummyHighlightProperty>();
             HighlightObjectBehavior highlightBehavior = new HighlightObjectBehavior(highlightProperty, highlightColor);
         
@@ -261,7 +269,8 @@ namespace Innoactive.Creator.XRInteraction.Tests.Behaviors
         {
             // Given a HighlightObjectBehavior with a HighlightProperty.
             Color highlightColor = Color.black;
-            GameObject interactable = new GameObject(targetName);
+            GameObject interactable = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            interactable.name = targetName;
             DummyHighlightProperty highlightProperty = interactable.AddComponent<DummyHighlightProperty>();
             HighlightObjectBehavior highlightBehavior = new HighlightObjectBehavior(highlightProperty, highlightColor);
             highlightBehavior.Configure(RuntimeConfigurator.Configuration.Modes.CurrentMode);


### PR DESCRIPTION
fix: the preview highlight mesh is now cached in the editor
fix: the preview highlight mesh does not have an offset

### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: An issue that used to highlight baked meshes (static objects) along with other baked meshes. 

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Use the `Highlight Behavior` to highlight a static object.


Before:
![image](https://user-images.githubusercontent.com/6911992/94454567-4e09be80-01b2-11eb-98b1-fd6ca6c93339.png)

After:
![image](https://user-images.githubusercontent.com/6911992/94454502-36323a80-01b2-11eb-8bc2-b08b7c8308a6.png)

Complex objects with multiple renderers and submeshes either static and non static being highlighted at the same time.
