### PR TITLE
Hotfix for children of a highlighted object

### DIFF
--- a/Runtime/Interaction/SnapZone.cs
+++ b/Runtime/Interaction/SnapZone.cs
@@ -332,7 +332,7 @@ namespace Innoactive.Creator.XRInteraction
                     {
                         subMeshIndex = i,
                         mesh = meshFilter.sharedMesh,
-                        transform = Matrix4x4.identity
+                        transform = meshFilter.transform.localToWorldMatrix
                     };
 
                     meshes.Add(combineInstance);


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: In some scenarios, children objects of a highlighted object were incorrectly rendered at its origin.
It also solves the same issue for snap zones.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Use the highlight behavior with an object with some children.
Create a snap zone from an object with some children.