### PR TITLE
fix: use specific Unity XR Interaction Toolkit package

### DIFF
--- a/Editor/Innoactive.CreatorEditor.XRInteraction.asmdef
+++ b/Editor/Innoactive.CreatorEditor.XRInteraction.asmdef
@@ -22,7 +22,7 @@
     "versionDefines": [
         {
             "name": "com.unity.xr.interaction.toolkit",
-            "expression": "",
+            "expression": "[0.9.4-preview]",
             "define": "XR_INTERACTION_TOOLKIT"
         }
     ],

--- a/Editor/PackageDependencies/XRInteractionPackageEnabler.cs
+++ b/Editor/PackageDependencies/XRInteractionPackageEnabler.cs
@@ -6,7 +6,7 @@
     public class XRInteractionPackageEnabler : Dependency 
     {        
         /// <inheritdoc/>
-        public override string Package { get; } = "com.unity.xr.interaction.toolkit";
+        public override string Package { get; } = "com.unity.xr.interaction.toolkit@0.9.4-preview";
 
         /// <inheritdoc/>
         public override int Priority { get; } = 4;


### PR DESCRIPTION
### Description
Since Unity updated its "XR Interaction Framework" package to v0.10.0-preview.7,
our Creator component is not compatible to it anymore.
For the next release, we use the older compatible version v0.9.4-preview.

**Fixes**:  [TRNG-1272](https://jira.innoactive.de/browse/TRNG-1272)

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Imported the Creator and all its components (including the XR-Interaction-Component). It now uses the compatible v0.9.4-preview version instead of the newest v0.10.0-preview.7 version which is incompatible.

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [x] My code follows the [Coding Conventions](#coding-conventions)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules