### PR TITLE
fix: offset when grabbing multiple objects with attach points TRNG-1288

### DIFF
--- a/Runtime/Interaction/DirectInteractor.cs
+++ b/Runtime/Interaction/DirectInteractor.cs
@@ -91,5 +91,20 @@ namespace Innoactive.Creator.XRInteraction
             
             base.OnSelectEnter(interactable);
         }
+        
+        /// <summary>
+        /// This method is called by the interaction manager when the interactor ends selection of an interactable.
+        /// </summary>
+        /// <param name="interactable">Interactable that is no longer selected.</param>
+        protected override void OnSelectExit(XRBaseInteractable interactable)
+        {
+            base.OnSelectExit(interactable);
+            
+            if (precisionGrab)
+            {
+                attachTransform.localPosition = initialAttachPosition;
+                attachTransform.localRotation = initialAttachRotation;
+            }
+        }
     }
 }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: An issue that appears in interactable objects that have attach transform points after previously grab objects without attach transform points.

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Grab an object that does not have an attach transform (it should be grabbed using precision grab), then grab another object that has an attach transform (it should be grabbed from the attach transform position).