### PR TITLE
XRIT API update

### DIFF
--- a/Runtime/Innoactive.Creator.XRInteraction.asmdef
+++ b/Runtime/Innoactive.Creator.XRInteraction.asmdef
@@ -25,6 +25,11 @@
             "name": "com.unity.xr.interaction.toolkit",
             "expression": "0.10.0-preview",
             "define": "XRIT_0_10_OR_NEWER"
+        },
+        {
+            "name": "com.unity.xr.interaction.toolkit",
+            "expression": "1.0.0-pre.2",
+            "define": "XRIT_1_0_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Interaction/Interactables/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Interactables/InteractableHighlighter.cs
@@ -109,6 +109,12 @@ namespace Innoactive.Creator.XRInteraction
             interactableObject.selectExited.AddListener(OnReleased);
             interactableObject.activated.AddListener(OnUsed);
             interactableObject.deactivated.AddListener(OnUnused);
+#elif XRIT_0_10_OR_NEWER
+            interactableObject.onFirstHoverEntered.AddListener(OnTouched);
+            interactableObject.onSelectEntered.AddListener(OnGrabbed);
+            interactableObject.onSelectExited.AddListener(OnReleased);
+            interactableObject.onActivate.AddListener(OnUsed);
+            interactableObject.onDeactivate.AddListener(OnUnused);
 #else
             interactableObject.onFirstHoverEnter.AddListener(OnTouched);
             interactableObject.onSelectEnter.AddListener(OnGrabbed);
@@ -137,6 +143,12 @@ namespace Innoactive.Creator.XRInteraction
             interactableObject.selectExited.RemoveListener(OnReleased);
             interactableObject.activated.RemoveListener(OnUsed);
             interactableObject.deactivated.RemoveListener(OnUnused);
+#elif XRIT_0_10_OR_NEWER
+            interactableObject.onFirstHoverEntered.RemoveListener(OnTouched);
+            interactableObject.onSelectEntered.RemoveListener(OnGrabbed);
+            interactableObject.onSelectExited.RemoveListener(OnReleased);
+            interactableObject.onActivate.RemoveListener(OnUsed);
+            interactableObject.onDeactivate.RemoveListener(OnUnused);
 #else
             interactableObject.onFirstHoverEnter.RemoveListener(OnTouched);
             interactableObject.onSelectEnter.RemoveListener(OnGrabbed);

--- a/Runtime/Interaction/Interactables/InteractableHighlighter.cs
+++ b/Runtime/Interaction/Interactables/InteractableHighlighter.cs
@@ -103,17 +103,19 @@ namespace Innoactive.Creator.XRInteraction
                 interactableObject = gameObject.GetComponent<InteractableObject>();
             }
 
-#if XRIT_0_10_OR_NEWER
-            interactableObject.onFirstHoverEntered.AddListener(OnTouched);
-            interactableObject.onSelectEntered.AddListener(OnGrabbed);
-            interactableObject.onSelectExited.AddListener(OnReleased);
+#if XRIT_1_0_OR_NEWER
+            interactableObject.firstHoverEntered.AddListener(OnTouched);
+            interactableObject.selectEntered.AddListener(OnGrabbed);
+            interactableObject.selectExited.AddListener(OnReleased);
+            interactableObject.activated.AddListener(OnUsed);
+            interactableObject.deactivated.AddListener(OnUnused);
 #else
             interactableObject.onFirstHoverEnter.AddListener(OnTouched);
             interactableObject.onSelectEnter.AddListener(OnGrabbed);
             interactableObject.onSelectExit.AddListener(OnReleased);
-#endif
             interactableObject.onActivate.AddListener(OnUsed);
             interactableObject.onDeactivate.AddListener(OnUnused);
+#endif
         }
 
         private void OnDisable()
@@ -124,17 +126,24 @@ namespace Innoactive.Creator.XRInteraction
                 externalHighlights.Clear();
             }
             
-#if XRIT_0_10_OR_NEWER
-            interactableObject?.onFirstHoverEntered.RemoveListener(OnTouched);
-            interactableObject?.onSelectEntered.RemoveListener(OnGrabbed);
-            interactableObject?.onSelectExited.RemoveListener(OnReleased);
+            if (interactableObject == false)
+            {
+                return;
+            }
+            
+#if XRIT_1_0_OR_NEWER
+            interactableObject.firstHoverEntered.RemoveListener(OnTouched);
+            interactableObject.selectEntered.RemoveListener(OnGrabbed);
+            interactableObject.selectExited.RemoveListener(OnReleased);
+            interactableObject.activated.RemoveListener(OnUsed);
+            interactableObject.deactivated.RemoveListener(OnUnused);
 #else
-            interactableObject?.onFirstHoverEnter.RemoveListener(OnTouched);
-            interactableObject?.onSelectEnter.RemoveListener(OnGrabbed);
-            interactableObject?.onSelectExit.RemoveListener(OnReleased);
+            interactableObject.onFirstHoverEnter.RemoveListener(OnTouched);
+            interactableObject.onSelectEnter.RemoveListener(OnGrabbed);
+            interactableObject.onSelectExit.RemoveListener(OnReleased);
+            interactableObject.onActivate.RemoveListener(OnUsed);
+            interactableObject.onDeactivate.RemoveListener(OnUnused);
 #endif
-            interactableObject?.onActivate.RemoveListener(OnUsed);
-            interactableObject?.onDeactivate.RemoveListener(OnUnused);
         }
 
         private void OnValidate()
@@ -225,6 +234,33 @@ namespace Innoactive.Creator.XRInteraction
             }
         }
 
+#if XRIT_1_0_OR_NEWER
+        private void OnTouched(HoverEnterEventArgs arguments)
+        {
+            OnTouchHighlight();
+        }
+        
+        private void OnGrabbed(SelectEnterEventArgs arguments)
+        {
+            OnGrabHighlight();
+        }
+        
+        private void OnReleased(SelectExitEventArgs arguments)
+        {
+            OnTouchHighlight();
+        }
+        
+        private void OnUsed(ActivateEventArgs arguments)
+        {
+            OnUseHighlight();
+        }
+        
+        private void OnUnused(DeactivateEventArgs arg0)
+        {
+            OnGrabHighlight();
+        }
+#else
+
         private void OnTouched(XRBaseInteractor interactor)
         {
             OnTouchHighlight();
@@ -249,7 +285,7 @@ namespace Innoactive.Creator.XRInteraction
         {
             OnGrabHighlight();
         }
-
+#endif
         private IEnumerator Highlight(Material highlightMaterial, Func<bool> shouldContinueHighlighting, string highlightID = "")
         {
             if (highlightMeshRenderer == null || renderers == null || renderers.Any() == false)

--- a/Runtime/Interaction/Interactables/InteractableObject.cs
+++ b/Runtime/Interaction/Interactables/InteractableObject.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 
@@ -145,7 +142,15 @@ namespace Innoactive.Creator.XRInteraction
         {
             if (IsActivated)
             {
+#if XRIT_1_0_OR_NEWER
+                OnDeactivated(new DeactivateEventArgs
+                {
+                    interactable =  this,
+                    interactor = selectingInteractor
+                });
+#else
                 OnDeactivate(selectingInteractor);
+#endif
             }
             
             StartCoroutine(StopInteractingForOneFrame());
@@ -156,26 +161,58 @@ namespace Innoactive.Creator.XRInteraction
         /// </summary>
         public virtual void ForceUse()
         {
+#if XRIT_1_0_OR_NEWER
+            OnActivated(new ActivateEventArgs
+            {
+                interactable = this,
+                interactor = selectingInteractor
+            });
+#else
             OnActivate(selectingInteractor);
+#endif
         }
 
         internal void ForceSelectEnter(XRBaseInteractor interactor)
         {
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            OnSelectEntering(new SelectEnterEventArgs
+            {
+                interactable = this,
+                interactor = interactor
+            });
+#elif XRIT_0_10_OR_NEWER
             OnSelectEntering(interactor);
 #else
             OnSelectEnter(interactor);
 #endif
         }
         
+#if XRIT_1_0_OR_NEWER
+        /// <summary>
+        /// This method is called by the Interaction Manager
+        /// right before the Interactor first initiates selection of an Interactable
+        /// in a first pass.
+        /// </summary>
+        /// <param name="arguments">Event data containing the Interactor that is initiating the selection.</param>
+        /// <remarks>
+        /// <paramref name="arguments"/> is only valid during this method call, do not hold a reference to it.
+        /// </remarks>
+        /// <seealso cref="OnSelectEntered(SelectEnterEventArgs)"/>
+        protected override void OnSelectEntering(SelectEnterEventArgs arguments)
+        {
+            base.OnSelectEntering(arguments);
+            XRBaseInteractor interactor = arguments.interactor;
+#elif XRIT_0_10_OR_NEWER
         /// <summary>This method is called by the interaction manager 
         /// when the interactor first initiates selection of an interactable.</summary>
         /// <param name="interactor">Interactor that is initiating the selection.</param>
-#if XRIT_0_10_OR_NEWER
         protected override void OnSelectEntering(XRBaseInteractor interactor)
         {
             base.OnSelectEntering(interactor);
 #else
+        /// <summary>This method is called by the interaction manager 
+        /// when the interactor first initiates selection of an interactable.</summary>
+        /// <param name="interactor">Interactor that is initiating the selection.</param>
         protected override void OnSelectEnter(XRBaseInteractor interactor)
         {
             base.OnSelectEnter(interactor);
@@ -191,15 +228,33 @@ namespace Innoactive.Creator.XRInteraction
                 }
             }
         }
-
+        
+#if XRIT_1_0_OR_NEWER
+        /// <summary>
+        /// This method is called by the Interaction Manager
+        /// right before the Interactor ends selection of an Interactable
+        /// in a first pass.
+        /// </summary>
+        /// <param name="arguments">Event data containing the Interactor that is ending the selection.</param>
+        /// <remarks>
+        /// <paramref name="arguments"/> is only valid during this method call, do not hold a reference to it.
+        /// </remarks>
+        /// <seealso cref="OnSelectExited(SelectExitEventArgs)"/>
+        protected override void OnSelectExiting(SelectExitEventArgs arguments)
+        {
+            base.OnSelectExiting(arguments);
+            XRBaseInteractor interactor = arguments.interactor;
+#elif XRIT_0_10_OR_NEWER
         /// <summary>This method is called by the interaction manager 
         /// when the interactor ends selection of an interactable.</summary>
         /// <param name="interactor">Interactor that is ending the selection.</param>
-#if XRIT_0_10_OR_NEWER
         protected override void OnSelectExiting(XRBaseInteractor interactor)
         {
             base.OnSelectExiting(interactor);
 #else
+        /// <summary>This method is called by the interaction manager 
+        /// when the interactor ends selection of an interactable.</summary>
+        /// <param name="interactor">Interactor that is ending the selection.</param>
         protected override void OnSelectExit(XRBaseInteractor interactor)
         {
             base.OnSelectExit(interactor);
@@ -209,7 +264,26 @@ namespace Innoactive.Creator.XRInteraction
                 selectingSocket = null;
             }
         }
-
+        
+#if XRIT_1_0_OR_NEWER
+        /// <summary>
+        /// This method is called by the <see cref="XRBaseControllerInteractor"/>
+        /// when the Interactor begins an activation event on this selected Interactable.
+        /// </summary>
+        /// <param name="arguments">Event data containing the Interactor that is sending the activate event.</param>
+        /// <remarks>
+        /// <paramref name="arguments"/> is only valid during this method call, do not hold a reference to it.
+        /// </remarks>
+        /// <seealso cref="OnDeactivated"/>
+        protected override void OnActivated(ActivateEventArgs arguments)
+        {
+            if (isUsable)
+            {
+                IsActivated = true;
+                base.OnActivated(arguments);
+            }
+        }
+#else
         /// <summary>This method is called by the interaction manager 
         /// when the interactor sends an activation event down to an interactable.</summary>
         /// <param name="interactor">Interactor that is sending the activation event.</param>
@@ -221,7 +295,28 @@ namespace Innoactive.Creator.XRInteraction
                 base.OnActivate(interactor);
             }
         }
+#endif
 
+#if XRIT_1_0_OR_NEWER
+        /// <summary>
+        /// This method is called by the <see cref="XRBaseControllerInteractor"/>
+        /// when the Interactor ends an activation event on this selected Interactable.
+        /// </summary>
+        /// <param name="arguments">Event data containing the Interactor that is sending the deactivate event.</param>
+        /// <remarks>
+        /// <paramref name="arguments"/> is only valid during this method call, do not hold a reference to it.
+        /// </remarks>
+        /// <seealso cref="OnActivated"/>
+        protected override void OnDeactivated(DeactivateEventArgs arguments)
+        {
+            if (isUsable)
+            {
+                IsActivated = false;
+                base.OnDeactivated(arguments);
+            }
+        }
+        
+#else
         /// <summary>This method is called by the interaction manager 
         /// when the interactor sends a deactivation event down to an interactable.</summary>
         /// <param name="interactor">Interactor that is sending the activation event.</param>
@@ -233,6 +328,7 @@ namespace Innoactive.Creator.XRInteraction
                 base.OnDeactivate(interactor);
             }
         }
+#endif
 
         private IEnumerator StopInteractingForOneFrame()
         {
@@ -242,7 +338,7 @@ namespace Innoactive.Creator.XRInteraction
             if (selectingSocket != null)
             {
                 SnapZone snapZone = selectingSocket as SnapZone;
-                snapZone.ForceUnselect();
+                snapZone?.ForceUnselect();
             }
             
             yield return new WaitUntil(() => hoveringInteractors.Count == 0 && selectingInteractor == null);

--- a/Runtime/Interaction/Interactables/InteractableObject.cs
+++ b/Runtime/Interaction/Interactables/InteractableObject.cs
@@ -206,6 +206,7 @@ namespace Innoactive.Creator.XRInteraction
         /// <summary>This method is called by the interaction manager 
         /// when the interactor first initiates selection of an interactable.</summary>
         /// <param name="interactor">Interactor that is initiating the selection.</param>
+        [System.Obsolete("OnSelectEntering(XRBaseInteractor) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectEntering(XRBaseInteractor interactor)
         {
             base.OnSelectEntering(interactor);
@@ -213,6 +214,7 @@ namespace Innoactive.Creator.XRInteraction
         /// <summary>This method is called by the interaction manager 
         /// when the interactor first initiates selection of an interactable.</summary>
         /// <param name="interactor">Interactor that is initiating the selection.</param>
+        [System.Obsolete("OnSelectEnter(XRBaseInteractor) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectEnter(XRBaseInteractor interactor)
         {
             base.OnSelectEnter(interactor);
@@ -248,6 +250,7 @@ namespace Innoactive.Creator.XRInteraction
         /// <summary>This method is called by the interaction manager 
         /// when the interactor ends selection of an interactable.</summary>
         /// <param name="interactor">Interactor that is ending the selection.</param>
+        [System.Obsolete("OnSelectExiting(XRBaseInteractor) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectExiting(XRBaseInteractor interactor)
         {
             base.OnSelectExiting(interactor);
@@ -255,6 +258,7 @@ namespace Innoactive.Creator.XRInteraction
         /// <summary>This method is called by the interaction manager 
         /// when the interactor ends selection of an interactable.</summary>
         /// <param name="interactor">Interactor that is ending the selection.</param>
+        [System.Obsolete("OnSelectExit(XRBaseInteractor) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectExit(XRBaseInteractor interactor)
         {
             base.OnSelectExit(interactor);
@@ -287,6 +291,7 @@ namespace Innoactive.Creator.XRInteraction
         /// <summary>This method is called by the interaction manager 
         /// when the interactor sends an activation event down to an interactable.</summary>
         /// <param name="interactor">Interactor that is sending the activation event.</param>
+        [System.Obsolete("OnActivate(XRBaseInteractor) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnActivate(XRBaseInteractor interactor)
         {
             if (isUsable)
@@ -320,6 +325,7 @@ namespace Innoactive.Creator.XRInteraction
         /// <summary>This method is called by the interaction manager 
         /// when the interactor sends a deactivation event down to an interactable.</summary>
         /// <param name="interactor">Interactor that is sending the activation event.</param>
+        [System.Obsolete("OnDeactivate(XRBaseInteractor) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnDeactivate(XRBaseInteractor interactor)
         {
             if (isUsable)

--- a/Runtime/Interaction/Interactors/DirectInteractor.cs
+++ b/Runtime/Interaction/Interactors/DirectInteractor.cs
@@ -103,6 +103,7 @@ namespace Innoactive.Creator.XRInteraction
         /// This method is called when the interactor first initiates selection of an interactable.
         /// </summary>
         /// <param name="interactable">Interactable that is being selected.</param>
+        [System.Obsolete("OnSelectEntering(XRBaseInteractable) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectEntering(XRBaseInteractable interactable)
         {
             InteractableObject interactableObject = interactable as InteractableObject;
@@ -129,6 +130,7 @@ namespace Innoactive.Creator.XRInteraction
         /// This method is called when the interactor first initiates selection of an interactable.
         /// </summary>
         /// <param name="interactable">Interactable that is being selected.</param>
+        [System.Obsolete("OnSelectEnter(XRBaseInteractable) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectEnter(XRBaseInteractable interactable)
         {
             InteractableObject interactableObject = interactable as InteractableObject;
@@ -170,6 +172,7 @@ namespace Innoactive.Creator.XRInteraction
         /// This method is called by the interaction manager when the interactor ends selection of an interactable.
         /// </summary>
         /// <param name="interactable">Interactable that is no longer selected.</param>
+        [System.Obsolete("OnSelectExiting(XRBaseInteractable) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectExiting(XRBaseInteractable interactable)
         {
             base.OnSelectExiting(interactable);
@@ -178,6 +181,7 @@ namespace Innoactive.Creator.XRInteraction
         /// This method is called by the interaction manager when the interactor ends selection of an interactable.
         /// </summary>
         /// <param name="interactable">Interactable that is no longer selected.</param>
+        [System.Obsolete("OnSelectExit(XRBaseInteractable) has been deprecated. Please, upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.")]
         protected override void OnSelectExit(XRBaseInteractable interactable)
         {
             base.OnSelectExit(interactable);

--- a/Runtime/Interaction/Interactors/SnapZone.cs
+++ b/Runtime/Interaction/Interactors/SnapZone.cs
@@ -205,7 +205,10 @@ namespace Innoactive.Creator.XRInteraction
             
             snapZoneHoverTargets.Clear();
             
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            selectEntered.AddListener(OnAttach);
+            selectExited.AddListener(OnDetach);
+#elif XRIT_0_10_OR_NEWER
             onSelectEntered.AddListener(OnAttach);
             onSelectExited.AddListener(OnDetach);
 #else
@@ -221,7 +224,10 @@ namespace Innoactive.Creator.XRInteraction
             AttachParent();
             snapZoneHoverTargets.Clear();
 
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            selectEntered.RemoveListener(OnAttach);
+            selectExited.RemoveListener(OnDetach);
+#elif XRIT_0_10_OR_NEWER
             onSelectEntered.RemoveListener(OnAttach);
             onSelectExited.RemoveListener(OnDetach);
 #else
@@ -230,8 +236,15 @@ namespace Innoactive.Creator.XRInteraction
 #endif
         }
 
+
+#if XRIT_1_0_OR_NEWER
+        private void OnAttach(SelectEnterEventArgs arguments)
+        {
+            XRBaseInteractable interactable = arguments.interactable;
+#else
         private void OnAttach(XRBaseInteractable interactable)
         {
+#endif
             if (interactable != null)
             {
                 Rigidbody rigid = interactable.gameObject.GetComponent<Rigidbody>();
@@ -240,8 +253,14 @@ namespace Innoactive.Creator.XRInteraction
             }
         }
         
+#if XRIT_1_0_OR_NEWER
+        private void OnDetach(SelectExitEventArgs arguments)
+        {
+            XRBaseInteractable interactable = arguments.interactable;
+#else
         private void OnDetach(XRBaseInteractable interactable)
         {
+#endif
             if (interactable != null)
             {
                 Rigidbody rigid = interactable.gameObject.GetComponent<Rigidbody>();
@@ -469,7 +488,13 @@ namespace Innoactive.Creator.XRInteraction
 
             if (interactable.IsSelectableBy(this))
             {
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+                OnSelectEntering(new SelectEnterEventArgs
+                {
+                    interactable = interactable,
+                    interactor = this
+                });
+#elif XRIT_0_10_OR_NEWER
                 OnSelectEntering(interactable);
 #else
                 OnSelectEnter(interactable);
@@ -480,8 +505,7 @@ namespace Innoactive.Creator.XRInteraction
                     interactableObject.ForceSelectEnter(this);
                 }
                 
-                interactable.transform.position = attachTransform.position;
-                interactable.transform.rotation = attachTransform.rotation;
+                interactable.transform.SetPositionAndRotation(attachTransform.position, attachTransform.rotation);
                 ForceSelectTarget = interactable;
             }
             else

--- a/Runtime/Properties/GrabbableProperty.cs
+++ b/Runtime/Properties/GrabbableProperty.cs
@@ -43,7 +43,10 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             base.OnEnable();
 
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            Interactable.selectEntered.AddListener(HandleXRGrabbed);
+            Interactable.selectExited.AddListener(HandleXRUngrabbed);
+#elif XRIT_0_10_OR_NEWER
             Interactable.onSelectEntered.AddListener(HandleXRGrabbed);
             Interactable.onSelectExited.AddListener(HandleXRUngrabbed);
 #else
@@ -58,7 +61,10 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             base.OnDisable();
         
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            Interactable.selectEntered.RemoveListener(HandleXRGrabbed);
+            Interactable.selectExited.RemoveListener(HandleXRUngrabbed);
+#elif XRIT_0_10_OR_NEWER
             Interactable.onSelectEntered.RemoveListener(HandleXRGrabbed);
             Interactable.onSelectExited.RemoveListener(HandleXRUngrabbed);
 #else
@@ -66,19 +72,27 @@ namespace Innoactive.Creator.XRInteraction.Properties
             Interactable.onSelectExit.RemoveListener(HandleXRUngrabbed);
 #endif
         }
-        
+
         protected void Reset()
         {
             Interactable.IsGrabbable = true;
             GetComponent<Rigidbody>().isKinematic = false;
         }
 
+#if XRIT_1_0_OR_NEWER
+        private void HandleXRGrabbed(SelectEnterEventArgs arguments)
+#else
         private void HandleXRGrabbed(XRBaseInteractor interactor)
+#endif
         {
             EmitGrabbed();
         }
 
+#if XRIT_1_0_OR_NEWER
+        private void HandleXRUngrabbed(SelectExitEventArgs arguments)
+#else
         private void HandleXRUngrabbed(XRBaseInteractor interactor)
+#endif
         {
             EmitUngrabbed();
         }

--- a/Runtime/Properties/SnapZoneProperty.cs
+++ b/Runtime/Properties/SnapZoneProperty.cs
@@ -67,7 +67,10 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             base.OnEnable();
         
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            SnapZone.selectEntered.AddListener(HandleObjectSnapped);
+            SnapZone.selectExited.AddListener(HandleObjectUnsnapped);
+#elif XRIT_0_10_OR_NEWER
             SnapZone.onSelectEntered.AddListener(HandleObjectSnapped);
             SnapZone.onSelectExited.AddListener(HandleObjectUnsnapped);
 #else
@@ -80,7 +83,11 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             base.OnDisable();
 
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            SnapZone.selectEntered.RemoveListener(HandleObjectSnapped);
+            SnapZone.selectExited.RemoveListener(HandleObjectUnsnapped);
+
+#elif XRIT_0_10_OR_NEWER
             SnapZone.onSelectEntered.RemoveListener(HandleObjectSnapped);
             SnapZone.onSelectExited.RemoveListener(HandleObjectUnsnapped);
 #else
@@ -89,8 +96,14 @@ namespace Innoactive.Creator.XRInteraction.Properties
 #endif
         }
         
+#if XRIT_1_0_OR_NEWER
+        private void HandleObjectSnapped(SelectEnterEventArgs arguments)
+        {
+            XRBaseInteractable interactable = arguments.interactable;
+#else
         private void HandleObjectSnapped(XRBaseInteractable interactable)
         {
+#endif
             SnappedObject = interactable.gameObject.GetComponent<SnappableProperty>();
             if (SnappedObject == null)
             {
@@ -102,7 +115,11 @@ namespace Innoactive.Creator.XRInteraction.Properties
             }
         }
         
+#if XRIT_1_0_OR_NEWER
+        private void HandleObjectUnsnapped(SelectExitEventArgs arguments)
+#else
         private void HandleObjectUnsnapped(XRBaseInteractable interactable)
+#endif
         {
             if (SnappedObject != null)
             {

--- a/Runtime/Properties/SnappableProperty.cs
+++ b/Runtime/Properties/SnappableProperty.cs
@@ -58,7 +58,10 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             base.OnEnable();
 
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            Interactable.selectEntered.AddListener(HandleSnappedToDropZone);
+            Interactable.selectExited.AddListener(HandleUnsnappedFromDropZone);
+#elif XRIT_0_10_OR_NEWER
             Interactable.onSelectEntered.AddListener(HandleSnappedToDropZone);
             Interactable.onSelectExited.AddListener(HandleUnsnappedFromDropZone);
 #else
@@ -71,7 +74,10 @@ namespace Innoactive.Creator.XRInteraction.Properties
         
         protected new virtual void OnDisable()
         {
-#if XRIT_0_10_OR_NEWER
+#if XRIT_1_0_OR_NEWER
+            Interactable.selectEntered.RemoveListener(HandleSnappedToDropZone);
+            Interactable.selectExited.RemoveListener(HandleUnsnappedFromDropZone);
+#elif XRIT_0_10_OR_NEWER
             Interactable.onSelectEntered.RemoveListener(HandleSnappedToDropZone);
             Interactable.onSelectEntered.RemoveListener(HandleUnsnappedFromDropZone);
 #else
@@ -80,9 +86,15 @@ namespace Innoactive.Creator.XRInteraction.Properties
 #endif
         }
         
+#if XRIT_1_0_OR_NEWER
+        private void HandleSnappedToDropZone(SelectEnterEventArgs arguments)
+        {
+            XRBaseInteractor interactor = arguments.interactor;
+#else
         private void HandleSnappedToDropZone(XRBaseInteractor interactor)
         {
-            SnappedZone = interactor.GetComponent<SnapZoneProperty>();
+#endif
+        SnappedZone = interactor.GetComponent<SnapZoneProperty>();
 
             if (SnappedZone == null)
             {
@@ -98,7 +110,11 @@ namespace Innoactive.Creator.XRInteraction.Properties
             EmitSnapped();
         }
         
+#if XRIT_1_0_OR_NEWER
+        private void HandleUnsnappedFromDropZone(SelectExitEventArgs arguments)
+#else
         private void HandleUnsnappedFromDropZone(XRBaseInteractor interactor)
+#endif
         {
             SnappedZone = null;
             EmitUnsnapped();

--- a/Runtime/Properties/TouchableProperty.cs
+++ b/Runtime/Properties/TouchableProperty.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
 using Innoactive.Creator.Core.Properties;
@@ -42,7 +41,11 @@ namespace Innoactive.Creator.XRInteraction.Properties
         protected override void OnEnable()
         {
             base.OnEnable();
-#if XRIT_0_10_OR_NEWER
+            
+#if XRIT_1_0_OR_NEWER
+            Interactable.firstHoverEntered.AddListener(HandleXRTouched);
+            Interactable.lastHoverExited.AddListener(HandleXRUntouched);
+#elif XRIT_0_10_OR_NEWER
             Interactable.onFirstHoverEntered.AddListener(HandleXRTouched);
             Interactable.onLastHoverExited.AddListener(HandleXRUntouched);
 #else
@@ -56,7 +59,11 @@ namespace Innoactive.Creator.XRInteraction.Properties
         protected override void OnDisable()
         {
             base.OnDisable();
-#if XRIT_0_10_OR_NEWER
+            
+#if XRIT_1_0_OR_NEWER
+            Interactable.firstHoverEntered.RemoveListener(HandleXRTouched);
+            Interactable.lastHoverExited.RemoveListener(HandleXRUntouched);
+#elif XRIT_0_10_OR_NEWER
             Interactable.onFirstHoverEntered.RemoveListener(HandleXRTouched);
             Interactable.onLastHoverExited.RemoveListener(HandleXRUntouched);
 #else
@@ -71,12 +78,20 @@ namespace Innoactive.Creator.XRInteraction.Properties
             gameObject.GetComponent<Rigidbody>().isKinematic = false;
         }
 
+#if XRIT_1_0_OR_NEWER
+        private void HandleXRTouched(HoverEnterEventArgs arguments)
+#else
         private void HandleXRTouched(XRBaseInteractor interactor)
+#endif
         {
             EmitTouched();
         }
 
+#if XRIT_1_0_OR_NEWER
+        private void HandleXRUntouched(HoverExitEventArgs arguments)
+#else
         private void HandleXRUntouched(XRBaseInteractor interactor)
+#endif
         {
             EmitUntouched();
         }

--- a/Runtime/Properties/UsableProperty.cs
+++ b/Runtime/Properties/UsableProperty.cs
@@ -47,10 +47,14 @@ namespace Innoactive.Creator.XRInteraction.Properties
         protected override void OnEnable()
         {
             base.OnEnable();
-
+            
+#if XRIT_1_0_OR_NEWER
+            Interactable.activated.AddListener(HandleXRUsageStarted);
+            Interactable.deactivated.AddListener(HandleXRUsageStopped);
+#else
             Interactable.onActivate.AddListener(HandleXRUsageStarted);
             Interactable.onDeactivate.AddListener(HandleXRUsageStopped);
-
+#endif
             InternalSetLocked(IsLocked);
         }
 
@@ -58,22 +62,35 @@ namespace Innoactive.Creator.XRInteraction.Properties
         {
             base.OnDisable();
 
+#if XRIT_1_0_OR_NEWER
+            Interactable.activated.RemoveListener(HandleXRUsageStarted);
+            Interactable.deactivated.RemoveListener(HandleXRUsageStopped);
+#else
             Interactable.onActivate.RemoveListener(HandleXRUsageStarted);
             Interactable.onDeactivate.RemoveListener(HandleXRUsageStopped);
+#endif
         }
-        
+
         protected void Reset()
         {
             Interactable.IsUsable = true;
             gameObject.GetComponent<Rigidbody>().isKinematic = false;
         }
 
+#if XRIT_1_0_OR_NEWER
+        private void HandleXRUsageStarted(ActivateEventArgs arguments)
+#else
         private void HandleXRUsageStarted(XRBaseInteractor interactor)
+#endif
         {
             EmitUsageStarted();
         }
 
+#if XRIT_1_0_OR_NEWER
+        private void HandleXRUsageStopped(DeactivateEventArgs arguments)
+#else
         private void HandleXRUsageStopped(XRBaseInteractor interactor)
+#endif
         {
             EmitUsageStopped();
         }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The latest XRIT release (`1.0.0-pre.2` January 25) changed the signature of all interaction event methods causing the Creator to have 50 warnings from obsolete methods:

<img width="1440" alt="Screenshot 2021-01-29 at 21 01 40" src="https://user-images.githubusercontent.com/6911992/106321919-544d9b80-6275-11eb-8df7-0fe29dd64f38.png">

This PR fixes all, it also provides backward compatibility from `0.9.3-preview` to the current `1.0.0-pre2`.


### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

From the `Package Manager` jump between different versions of the `XR Interaction Toolkit` package, the Creator should work on all from the listed range.

![2021-01-29 at 21 20 00 - Violet Guan](https://user-images.githubusercontent.com/6911992/106323745-32a1e380-6278-11eb-8ae8-a4a7395cbb11.gif)
