### PR TITLE
fix: property name updated to latest XRIT API TRNG-1397

### DIFF
--- a/Editor/Innoactive.CreatorEditor.XRInteraction.asmdef
+++ b/Editor/Innoactive.CreatorEditor.XRInteraction.asmdef
@@ -29,6 +29,11 @@
             "name": "com.unity.xr.interaction.toolkit",
             "expression": "0.10.0-preview",
             "define": "XRIT_0_10_OR_NEWER"
+        },
+        {
+            "name": "com.unity.xr.interaction.toolkit",
+            "expression": "1.0.0-pre.2",
+            "define": "XRIT_1_0_OR_NEWER"
         }
     ],
     "noEngineReferences": false

--- a/Editor/Interaction/InteractableObjectEditor.cs
+++ b/Editor/Interaction/InteractableObjectEditor.cs
@@ -29,6 +29,10 @@ namespace Innoactive.CreatorEditor.XRInteraction
         private SerializedProperty gravityOnDetachProperty;
         private SerializedProperty retainTransformParentProperty;
         
+#if XRIT_1_0_OR_NEWER
+        private SerializedProperty customReticle;
+#endif
+        
         private SerializedProperty onFirstHoverEntered;
         private SerializedProperty onHoverEntered;
         private SerializedProperty onHoverExited;
@@ -78,6 +82,10 @@ namespace Innoactive.CreatorEditor.XRInteraction
             public static readonly GUIContent IsGrabbable = new GUIContent("Is Grabbable", "Determines if this Interactable Object can be grabbed.");
             public static readonly GUIContent IsUsable = new GUIContent("Is Usable", "Determines if this Interactable Object can be used.");
             public static readonly GUIContent HighlightOptions = new GUIContent("Enable Highlighting", "Adds an InteractableHighlighter component to this Interactable.");
+
+#if XRIT_1_0_OR_NEWER
+            public static readonly GUIContent CustomReticle = EditorGUIUtility.TrTextContent("Custom Reticle", "The reticle that will appear at the end of the line when it is valid.");
+#endif
         }
 
         private void OnEnable()
@@ -101,9 +109,16 @@ namespace Innoactive.CreatorEditor.XRInteraction
             throwSmoothingCurveProperty = serializedObject.FindProperty("m_ThrowSmoothingCurve");
             throwVelocityScaleProperty = serializedObject.FindProperty("m_ThrowVelocityScale");
             throwAngularVelocityScaleProperty = serializedObject.FindProperty("m_ThrowAngularVelocityScale");
-            gravityOnDetachProperty = serializedObject.FindProperty("m_GravityOnDetach");
             retainTransformParentProperty = serializedObject.FindProperty("m_RetainTransformParent");
             interactionManager = serializedObject.FindProperty("m_InteractionManager");
+            
+#if XRIT_1_0_OR_NEWER
+            gravityOnDetachProperty = serializedObject.FindProperty("m_ForceGravityOnDetach");
+            customReticle = serializedObject.FindProperty("m_CustomReticle");
+#else
+            gravityOnDetachProperty = serializedObject.FindProperty("m_GravityOnDetach");
+#endif
+                
 #if XRIT_0_10_OR_NEWER
             onFirstHoverEntered = serializedObject.FindProperty("m_OnFirstHoverEntered");
             onHoverEntered = serializedObject.FindProperty("m_OnHoverEntered");
@@ -153,6 +168,10 @@ namespace Innoactive.CreatorEditor.XRInteraction
             EditorGUILayout.PropertyField(interactionManager, Tooltips.InteractionManager);
             EditorGUILayout.PropertyField(interactionLayerMaskProperty, Tooltips.InteractionLayerMask);
             EditorGUILayout.PropertyField(collidersProperty, Tooltips.Colliders, true);
+            
+#if XRIT_1_0_OR_NEWER
+            EditorGUILayout.PropertyField(customReticle, Tooltips.CustomReticle);
+#endif
             
             EditorGUILayout.Space();
 

--- a/Editor/XRInteractionSceneSetup.cs
+++ b/Editor/XRInteractionSceneSetup.cs
@@ -4,15 +4,15 @@ using Innoactive.CreatorEditor.BasicInteraction;
 
 namespace Innoactive.CreatorEditor.XRInteraction
 {
-    
     /// <summary>
     /// Scene setup for XR-Interaction.
     /// </summary>
     public class XRInteractionSceneSetup : InteractionFrameworkSceneSetup
     {
         private const string Title = "Obsolete XR Ring detected";
-
-        private const string Message = "Creator changed the Rig loading to a new dynamic system, you still have the old XR_Setup in the current scene, do you want to delete it?";
+        
+        /// <inheritdoc />
+        public override string Key { get; } = "XRInteractionSetup";
         
         /// <inheritdoc />
         public override void Setup()
@@ -26,9 +26,9 @@ namespace Innoactive.CreatorEditor.XRInteraction
             
             if (objectToDelete != null)
             {
-                string Message = $"Creator changed the XR Rig loading to a new dynamic system, you have a static {objectName} in the current scene, do you want to delete it?";
+                string message = $"Creator changed the XR Rig loading to a new dynamic system, you have a static {objectName} in the current scene, do you want to delete it?";
                 
-                if (EditorUtility.DisplayDialog(Title, Message, "Delete", "Skip"))
+                if (EditorUtility.DisplayDialog(Title, message, "Delete", "Skip"))
                 {
                     EditorUtility.SetDirty(objectToDelete);
                     Object.DestroyImmediate(objectToDelete);

--- a/Runtime/Rigs/XRSetupBase.cs
+++ b/Runtime/Rigs/XRSetupBase.cs
@@ -8,7 +8,7 @@ namespace Innoactive.Creator.Components.Runtime.Rigs
     {
         protected bool IsEventManagerInScene()
         {
-            return GameObject.FindObjectOfType<XRInteractionManager>() != null;
+            return Object.FindObjectOfType<XRInteractionManager>() != null;
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

**Fixes**: 

- An issue where selecting an interactable object while been on the latest XRIT will throw multiple errors in the console.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/6911992/106611005-bbb26680-6567-11eb-8bec-910b0743d871.png">

- An issue where setting a training scene throws a warning.

<img width="1043" alt="image" src="https://user-images.githubusercontent.com/6911992/106610928-a1788880-6567-11eb-9865-c6ab5786e001.png">


### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)