### PR TITLE
fix: highlight property flags itself highlighted now

### DIFF
--- a/Runtime/Properties/HighlightProperty.cs
+++ b/Runtime/Properties/HighlightProperty.cs
@@ -61,6 +61,7 @@ namespace Innoactive.Creator.XRInteraction.Properties
         public override void Highlight(Color highlightColor)
         {
             CurrentHighlightColor = highlightColor;
+            IsHighlighted = true;
             Highlighter.StartHighlighting(SceneObject.UniqueName, highlightColor);
             EmitHighlightEvent();
         }
@@ -69,6 +70,7 @@ namespace Innoactive.Creator.XRInteraction.Properties
         public override void Unhighlight()
         {
             CurrentHighlightColor = null;
+            IsHighlighted = false;
             Highlighter.StopHighlighting(SceneObject.UniqueName);
             EmitUnhighlightEvent();
         }


### PR DESCRIPTION
### Description
The visual effect of the highlight property worked but it never set the IsHighlighted flag to true.

**Fixes**: # (issue)

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)