### PR TITLE
fix: rig loader now validates that prefab exits

### DIFF
--- a/Runtime/Rigs/XRLegacySetup.cs
+++ b/Runtime/Rigs/XRLegacySetup.cs
@@ -15,7 +15,7 @@
         public override bool CanBeUsed()
         {
 #if ENABLE_LEGACY_INPUT_MANAGER
-            return IsEventManagerInScene() == false;
+            return IsEventManagerInScene() == false && IsPrefabMissing == false;
 #else
             return false;
 #endif
@@ -24,6 +24,11 @@
         /// <inheritdoc />
         public override string GetSetupTooltip()
         {
+            if (IsPrefabMissing)
+            {
+                return $"The prefab {PrefabName} is missing in the Resources folder.";
+            }
+            
 #if ENABLE_LEGACY_INPUT_MANAGER
             return "Can't be used while there is already a XRInteractionManager in the scene.";
 #else

--- a/Runtime/Rigs/XRSetup.cs
+++ b/Runtime/Rigs/XRSetup.cs
@@ -17,7 +17,7 @@ namespace Innoactive.Creator.Components.Runtime.Rigs
         public override bool CanBeUsed()
         {
 #if ENABLE_INPUT_SYSTEM
-            return IsEventManagerInScene() == false;
+            return IsEventManagerInScene() == false && IsPrefabMissing == false;
 #else
             return false;
 #endif
@@ -26,6 +26,11 @@ namespace Innoactive.Creator.Components.Runtime.Rigs
         /// <inheritdoc />
         public override string GetSetupTooltip()
         {
+            if (IsPrefabMissing)
+            {
+                return $"The prefab {PrefabName} is missing in the Resources folder.";
+            }
+            
 #if ENABLE_INPUT_SYSTEM
             return "Can't be used while there is already a XRInteractionManager in the scene.";
 #else

--- a/Runtime/Rigs/XRSetupBase.cs
+++ b/Runtime/Rigs/XRSetupBase.cs
@@ -6,6 +6,14 @@ namespace Innoactive.Creator.Components.Runtime.Rigs
 {
     public abstract class XRSetupBase : InteractionRigProvider
     {
+        protected readonly bool IsPrefabMissing;
+        
+        public XRSetupBase()
+        {
+            IsPrefabMissing = Resources.Load(PrefabName) == null;
+            Resources.UnloadUnusedAssets();
+        }
+        
         protected bool IsEventManagerInScene()
         {
             return Object.FindObjectOfType<XRInteractionManager>() != null;

--- a/Runtime/Rigs/XRSimulatorSetup.cs
+++ b/Runtime/Rigs/XRSimulatorSetup.cs
@@ -10,12 +10,12 @@
         
         /// <inheritdoc />
         public override string PrefabName { get; } = "[XR_Setup_Simulator]";
-
+        
         /// <inheritdoc />
         public override bool CanBeUsed()
         {
 #if ENABLE_INPUT_SYSTEM && XRIT_1_0_OR_NEWER
-            return IsEventManagerInScene() == false;
+            return IsEventManagerInScene() == false && IsPrefabMissing == false;
 #else
             return false;
 #endif
@@ -24,6 +24,11 @@
         /// <inheritdoc />
         public override string GetSetupTooltip()
         {
+            if (IsPrefabMissing)
+            {
+                return $"The prefab {PrefabName} is missing in the Resources folder.";
+            }
+            
 #if !XRIT_1_0_OR_NEWER
             return "Please upgrade the XR Interaction Toolkit from the Package Manager to the latest available version.";
 #elif ENABLE_INPUT_SYSTEM


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The `Interaction Rig Loader` now validates that the prefabs exist for each rig.


https://user-images.githubusercontent.com/6911992/107626432-116cca00-6c5e-11eb-8c56-22775bbf1208.mp4


### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Try renaming, moving out from the `Resources` folder, or deleting the XR Rig prefabs, the `Interaction Rig Loader` should mark a Rig as invalid if its corresponding prefab is missing.

For testing purposes, the `[XR_Setup_Simulator]` can be deleted from the `XR-Interaction-Component/Resources` and regenerate by setting again the training scene from the innoactive menu.