### PR TITLE
fix: snapzone mode parameters now work

### DIFF
--- a/Runtime/Interaction/Interactors/SnapZone.cs
+++ b/Runtime/Interaction/Interactors/SnapZone.cs
@@ -454,6 +454,10 @@ namespace Innoactive.Creator.XRInteraction
             {
                 activeMaterial = snapZoneHoverTargets.Any(CanSelect) ? ValidationMaterial : InvalidMaterial;
             }
+            else
+            {
+                activeMaterial = null;
+            }
         }
 
         /// <summary>
@@ -461,7 +465,7 @@ namespace Innoactive.Creator.XRInteraction
         /// </summary>
         protected virtual void DrawHighlightMesh()
         {
-            if (PreviewMesh != null)
+            if (PreviewMesh != null && activeMaterial != null)
             {
                 Graphics.DrawMesh(PreviewMesh, attachTransform.localToWorldMatrix, activeMaterial, gameObject.layer, null);
             }


### PR DESCRIPTION
### Description
Fixed highlighting of snapzones for the case that mode parameters are used.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
With Modesexample scene

### Checklist
<!--- Make sure your PR meets the following criteria before opening it. -->

- [X] My code follows the [Coding Conventions](#coding-conventions)
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules