### PR TITLE
fix: make sure xr is loaded on scene load

### DIFF
--- a/Runtime/Innoactive.Creator.XRInteraction.asmdef
+++ b/Runtime/Innoactive.Creator.XRInteraction.asmdef
@@ -4,7 +4,8 @@
         "GUID:c8561f9de838ac04d8feeda695bc572d",
         "GUID:474da18fc7b8c9c4c9db09e343483375",
         "GUID:fe685ec1767f73d42b749ea8045bfe43",
-        "GUID:75469ad4d38634e559750d17036d5f7c"
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:e40ba710768534012815d3193fa296cb"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Runtime/Rigs/XRSetupBase.cs
+++ b/Runtime/Rigs/XRSetupBase.cs
@@ -1,6 +1,7 @@
 ﻿using Innoactive.Creator.BasicInteraction.RigSetup;
 using UnityEngine;
 using UnityEngine.XR.Interaction.Toolkit;
+using UnityEngine.XR.Management;
 
 namespace Innoactive.Creator.Components.Runtime.Rigs
 {
@@ -13,7 +14,19 @@ namespace Innoactive.Creator.Components.Runtime.Rigs
             IsPrefabMissing = Resources.Load(PrefabName) == null;
             Resources.UnloadUnusedAssets();
         }
-        
+
+        /// <summary>
+        /// Makes sure the XR loader and subsystem is set up.
+        /// </summary>
+        public override void PreSetup()
+        {
+            if (XRGeneralSettings.Instance.Manager.activeLoader == null)
+            {
+                XRGeneralSettings.Instance.Manager.InitializeLoaderSync();
+                XRGeneralSettings.Instance.Manager.StartSubsystems();
+            }
+        }
+
         protected bool IsEventManagerInScene()
         {
             return Object.FindObjectOfType<XRInteractionManager>() != null;


### PR DESCRIPTION
### Description
Makes sure Unity XR is properly initialized on scene load / rig setup


Related PRs:
https://github.com/Innoactive/Basic-Interaction-Component/pull/49