### PR TITLE
fix: exception if the snap zone drawer is not initialized

### DIFF
--- a/Runtime/Interaction/Interactors/SnapZonePreviewDrawer.cs
+++ b/Runtime/Interaction/Interactors/SnapZonePreviewDrawer.cs
@@ -19,7 +19,7 @@ namespace Innoactive.Creator.XRInteraction
         private MeshFilter filter;
         private MeshRenderer meshRenderer;
         
-        private void Start()
+        private void OnEnable()
         {
             if (Application.isPlaying)
             {


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

NRE if the snap zone drawer is not initialized

### Type of change
<!--- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update