### PR TITLE
fix: teleportation property is now fired when the rig is teleported

### DIFF
--- a/Runtime/Properties/TeleportationProperty.cs
+++ b/Runtime/Properties/TeleportationProperty.cs
@@ -33,15 +33,29 @@ namespace Innoactive.Creator.Core.Properties
         protected override void OnEnable()
         {
             base.OnEnable();
-            
-            teleportationInteractable.teleportationProvider.endLocomotion += EmitTeleported;
+
+            if (teleportationInteractable.teleportationProvider != null)
+            {
+                teleportationInteractable.teleportationProvider.endLocomotion += EmitTeleported;
+            }
+            else
+            {
+                Debug.LogWarning($"The 'TeleportationAnchor' from {name} is missing a reference to 'TeleportationProvider'.", gameObject);
+            }
         }
 
         protected override void OnDisable()
         {
             base.OnDisable();
-            
-            teleportationInteractable.teleportationProvider.endLocomotion -= EmitTeleported;
+
+            if (teleportationInteractable.teleportationProvider != null)
+            {
+                teleportationInteractable.teleportationProvider.endLocomotion -= EmitTeleported;
+            }
+            else
+            {
+                Debug.LogWarning($"The 'TeleportationAnchor' from {name} is missing a reference to 'TeleportationProvider'.", gameObject);
+            }
         }
 
         /// <inheritdoc />
@@ -61,7 +75,14 @@ namespace Innoactive.Creator.Core.Properties
                 destinationRotation = teleportationInteractable.teleportAnchorTransform.rotation
             };
 
-            teleportationInteractable.teleportationProvider.QueueTeleportRequest(teleportRequest);
+            if (teleportationInteractable.teleportationProvider != null)
+            {
+                teleportationInteractable.teleportationProvider.QueueTeleportRequest(teleportRequest);
+            }
+            else
+            {
+                Debug.LogError($"The 'TeleportationAnchor' from {name} is missing a reference to 'TeleportationProvider'.", gameObject);
+            }
         }
 
         /// <inheritdoc />

--- a/Runtime/Properties/TeleportationProperty.cs
+++ b/Runtime/Properties/TeleportationProperty.cs
@@ -33,36 +33,17 @@ namespace Innoactive.Creator.Core.Properties
         protected override void OnEnable()
         {
             base.OnEnable();
-
-            switch (teleportationInteractable.teleportTrigger)
-            {
-                case BaseTeleportationInteractable.TeleportTrigger.OnActivated:
-                    teleportationInteractable.activated.AddListener(args =>
-                    {
-                        EmitTeleported();
-                    });
-                    break;
-                case BaseTeleportationInteractable.TeleportTrigger.OnDeactivated:
-                    teleportationInteractable.deactivated.AddListener(args =>
-                    {
-                        EmitTeleported();
-                    });
-                    break;
-                case BaseTeleportationInteractable.TeleportTrigger.OnSelectEntered:
-                    teleportationInteractable.selectEntered.AddListener(args =>
-                    {
-                        EmitTeleported();
-                    });
-                    break;
-                case BaseTeleportationInteractable.TeleportTrigger.OnSelectExited:
-                    teleportationInteractable.selectExited.AddListener(args =>
-                    {
-                        EmitTeleported();
-                    });
-                    break;
-            }
+            
+            teleportationInteractable.teleportationProvider.endLocomotion += EmitTeleported;
         }
-        
+
+        protected override void OnDisable()
+        {
+            base.OnDisable();
+            
+            teleportationInteractable.teleportationProvider.endLocomotion -= EmitTeleported;
+        }
+
         /// <inheritdoc />
         public void Initialize()
         {
@@ -102,10 +83,21 @@ namespace Innoactive.Creator.Core.Properties
             }
         }
         
-        protected void EmitTeleported()
+        protected void EmitTeleported(LocomotionSystem locomotionSystem)
         {
-            wasUsedToTeleport = true;
-            Teleported?.Invoke(this, EventArgs.Empty);
+            if (wasUsedToTeleport == false)
+            {
+                Vector3 rigPosition = locomotionSystem.xrRig.rig.transform.position;
+                Vector3 anchorPosition = teleportationInteractable.teleportAnchorTransform.position;
+                Vector2 flatRigPosition = new Vector2(rigPosition.x, rigPosition.z);
+                Vector2 flatAnchorPosition = new Vector2(anchorPosition.x, anchorPosition.z);
+
+                if (Vector3.Distance(flatRigPosition, flatAnchorPosition) < 0.1)
+                {
+                    wasUsedToTeleport = true;
+                    Teleported?.Invoke(this, EventArgs.Empty);
+                }
+            }
         }
     }
 }

--- a/Tests/Runtime/TeleportConditionTest.cs
+++ b/Tests/Runtime/TeleportConditionTest.cs
@@ -1,25 +1,18 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using Innoactive.Creator.BasicInteraction.Conditions;
-using Innoactive.Creator.Core;
-using Innoactive.Creator.Core.Properties;
-using Innoactive.Creator.Tests.Utils;
+﻿using System;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using System.Collections;
+using System.Reflection;
+using Innoactive.Creator.Core;
+using Innoactive.Creator.Tests.Utils;
+using Innoactive.Creator.BasicInteraction.Conditions;
+using Innoactive.Creator.Core.Properties;
 
 namespace Innoactive.Creator.XRInteraction.Tests.Conditions
 {
     public class TeleportConditionTest : RuntimeTests
     {
-        public class TeleportationPropertyMock : TeleportationProperty
-        {
-            public new void EmitTeleported()
-            {
-                base.EmitTeleported();
-            }
-        }
-        
         [SetUp]
         public override void SetUp()
         {
@@ -167,6 +160,16 @@ namespace Innoactive.Creator.XRInteraction.Tests.Conditions
             // Then nothing happens.
             Assert.AreEqual(Stage.Active, condition.LifeCycle.Stage);
             Assert.IsFalse(condition.IsCompleted);
+        }
+    }
+    
+    public class TeleportationPropertyMock : TeleportationProperty
+    {
+        public void EmitTeleported()
+        {
+            Type type = typeof(TeleportationProperty);
+            FieldInfo fieldInfo = type.GetField("wasUsedToTeleport", BindingFlags.Instance | BindingFlags.NonPublic);
+            fieldInfo?.SetValue(this, true);
         }
     }
 }


### PR DESCRIPTION
### Description
<!---
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. If this PR fixes an open issue, please link it.
-->

The teleport property was fired when the selected teleport interaction event (OnActivated, OnDeactivated, OnSelectEntered, or OnSelectExited) was triggered, due to an architectural issue inside XRIT, this could happen without the XR Rig being teleported into the interactor (teleport property object).

This PR makes sure there was a teleportation action and the XR Rig is located in the teleport designated point.

### Type of change
<!--- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
<!---
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-->

Try to break the teleport condition.